### PR TITLE
Key translations into Polish

### DIFF
--- a/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
+++ b/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
@@ -7,18 +7,22 @@
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
         <source>BetterDisplay</source>
+        <target state="translated">BetterDisplay</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName" xml:space="preserve">
         <source>BetterDisplay</source>
+        <target state="translated">BetterDisplay</target>
         <note>Bundle name</note>
       </trans-unit>
       <trans-unit id="NSFileProviderDomainUsageDescription" xml:space="preserve">
         <source>The app needs to modify the system configuration to save the edited display data.</source>
+        <target state="translated">Aplikacja musi zmodyfikować ustawienia systemu, aby zapisać edytowane dane wyświetlacza.</target>
         <note>Privacy - Access to a File Provide Domain Usage Description</note>
       </trans-unit>
       <trans-unit id="NSHumanReadableCopyright" xml:space="preserve">
         <source>Copyright Ⓒ waydabber/KodeON</source>
+        <target state="translated">Copyright Ⓒ waydabber/KodeON</target>
         <note>Copyright (human-readable)</note>
       </trans-unit>
     </body>
@@ -30,6 +34,7 @@
     <body>
       <trans-unit id="" xml:space="preserve">
         <source/>
+        <target state="translated">(Pusty ciąg znaków)</target>
         <note/>
       </trans-unit>
       <trans-unit id="%" xml:space="preserve">
@@ -44,14 +49,17 @@
       </trans-unit>
       <trans-unit id="%@ (%@)" xml:space="preserve">
         <source>%1$@ (%2$@)</source>
+        <target state="translated">%1$@ (%2$@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ (%@)%@" xml:space="preserve">
         <source>%1$@ (%2$@)%3$@</source>
+        <target state="translated">%1$@ (%2$@)%3$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ - Swap Position" xml:space="preserve">
         <source>%@ - Swap Position</source>
+        <target state="translated">%@ - Zamień pozycję</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ Pro is Active" xml:space="preserve">
@@ -66,30 +74,37 @@
       </trans-unit>
       <trans-unit id="%@%%" xml:space="preserve">
         <source>%@%%</source>
+        <target state="translated">%@%%</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@%@" xml:space="preserve">
         <source>%1$@%2$@</source>
+        <target state="translated">%1$@%2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@%@%@" xml:space="preserve">
         <source>%1$@%2$@%3$@</source>
+        <target state="translated">%1$@%2$@%3$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@%@%@%@" xml:space="preserve">
         <source>%1$@%2$@%3$@%4$@</source>
+        <target state="translated">%1$@%2$@%3$@%4$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@, %@" xml:space="preserve">
         <source>%1$@, %2$@</source>
+        <target state="translated">%1$@, %2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@Hz" xml:space="preserve">
         <source>%@Hz</source>
+        <target state="translated">%@Hz</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@mm" xml:space="preserve">
         <source>%@mm</source>
+        <target state="translated">%@mm</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@mm x %@mm" xml:space="preserve">
@@ -99,10 +114,12 @@
       </trans-unit>
       <trans-unit id="%@x%@" xml:space="preserve">
         <source>%1$@x%2$@</source>
+        <target state="translated">%1$@x%2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@x%@%@ %@ %lld%@" xml:space="preserve">
         <source>%1$@x%2$@%3$@ %4$@ %5$lld%6$@</source>
+        <target state="translated">%1$@x%2$@%3$@ %4$@ %5$lld%6$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lf" xml:space="preserve">
@@ -122,22 +139,27 @@
       </trans-unit>
       <trans-unit id="%lld pixels HiDPI (%lld pixels LoDPI)" xml:space="preserve">
         <source>%1$lld pixels HiDPI (%2$lld pixels LoDPI)</source>
+        <target state="translated">%1$lld pikseli HiDPI (%2$lld pikseli LoDPI)</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld x %lld" xml:space="preserve">
         <source>%1$lld x %2$lld</source>
+        <target state="translated">%1$lld x %2$lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld x %lld %@ @ %lldHz" xml:space="preserve">
         <source>%1$lld x %2$lld %3$@ @ %4$lldHz</source>
+        <target state="translated">%1$lld x %2$lld %3$@ @ %4$lldHz</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld%@" xml:space="preserve">
         <source>%1$lld%2$@</source>
+        <target state="translated">%1$lld%2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld, %@" xml:space="preserve">
         <source>%1$lld, %2$@</source>
+        <target state="translated">%1$lld, %2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%u" xml:space="preserve">
@@ -147,6 +169,7 @@
       </trans-unit>
       <trans-unit id="%u bits per sample" xml:space="preserve">
         <source>%u bits per sample</source>
+        <target state="translated">%u bitów na próbkę</target>
         <note/>
       </trans-unit>
       <trans-unit id="(%@)" xml:space="preserve">
@@ -156,10 +179,12 @@
       </trans-unit>
       <trans-unit id="(next to %@)" xml:space="preserve">
         <source>(next to %@)</source>
+        <target state="translated">(obok %@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="(next to unspecified)" xml:space="preserve">
         <source>(next to unspecified)</source>
+        <target state="translated">(obok nieokreślonego)</target>
         <note/>
       </trans-unit>
       <trans-unit id="-" xml:space="preserve">
@@ -169,6 +194,7 @@
       </trans-unit>
       <trans-unit id="1:1 Pixel Mapping" xml:space="preserve">
         <source>1:1 Pixel Mapping</source>
+        <target state="translated">Mapowanie pikseli 1:1</target>
         <note/>
       </trans-unit>
       <trans-unit id="100" xml:space="preserve">
@@ -2170,6 +2196,7 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Display Notch" xml:space="preserve">
         <source>Display Notch</source>
+        <target state="translated">Wyświetl Notch</target>
         <note/>
       </trans-unit>
       <trans-unit id="Display group is configured to be always active regardless of the presence of group members." xml:space="preserve">
@@ -2328,7 +2355,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Done" xml:space="preserve">
         <source>Done</source>
-        <target state="translated">Zrobione</target>
+        <target state="translated">Gotowe</target>
         <note/>
       </trans-unit>
       <trans-unit id="Drag the app menu off the menu bar area (by holding the empty bottom area of the app menu) and make it persistently available." xml:space="preserve">
@@ -2884,6 +2911,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Have fun by creating an endless mirror from your desktop!" xml:space="preserve">
         <source>Have fun by creating an endless mirror from your desktop!</source>
+        <target state="translated">Baw się, tworząc niekończące się klony z pulpitu!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Height" xml:space="preserve">
@@ -3554,18 +3582,22 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Mirror Display" xml:space="preserve">
         <source>Mirror Display</source>
+        <target state="translated">Klonowanie ekranu</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirror Virtual Screen" xml:space="preserve">
         <source>Mirror Virtual Screen</source>
+        <target state="translated">Klonuj wirtualny wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirror of %@" xml:space="preserve">
         <source>Mirror of %@</source>
+        <target state="translated">Klon: %@</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirror the contents of this display to:" xml:space="preserve">
         <source>Mirror the contents of this display to:</source>
+        <target state="translated">Klonuj zawartość ekranu do:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirrored to %@" xml:space="preserve">
@@ -3606,14 +3638,17 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Move Display" xml:space="preserve">
         <source>Move Display</source>
+        <target state="translated">Przenieś wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Move Virtual Screen" xml:space="preserve">
         <source>Move Virtual Screen</source>
+        <target state="translated">Przenieś wirtualny wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Move this display next to:" xml:space="preserve">
         <source>Move this display next to:</source>
+        <target state="translated">Przenieś wyświetlacz obok:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Multiple Displays" xml:space="preserve">
@@ -3732,6 +3767,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="No Mirror Targets Available" xml:space="preserve">
         <source>No Mirror Targets Available</source>
+        <target state="translated">Brak dostępnych celów dla klonowania</target>
         <note/>
       </trans-unit>
       <trans-unit id="No Modes Available" xml:space="preserve">
@@ -4280,6 +4316,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Remove" xml:space="preserve">
         <source>Remove</source>
+        <target state="translated">Usuń</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove Color Profiles" xml:space="preserve">
@@ -4479,6 +4516,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Resume Stream on Connect" xml:space="preserve">
         <source>Resume Stream on Connect</source>
+        <target state="translated">Wznów strumieniowanie po połączeniu</target>
         <note/>
       </trans-unit>
       <trans-unit id="Retrieve EDID" xml:space="preserve">
@@ -5177,14 +5215,17 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Stream Display" xml:space="preserve">
         <source>Stream Display</source>
+        <target state="translated">Strumieniuj wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Stream Virtual Screen" xml:space="preserve">
         <source>Stream Virtual Screen</source>
+        <target state="translated">Strumieniuj wirtualny wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Stream the contents of this display to:" xml:space="preserve">
         <source>Stream the contents of this display to:</source>
+        <target state="translated">Strumieniuj zawartość tego wyświetlacza do:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Streaming from" xml:space="preserve">
@@ -6260,10 +6301,12 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="XDR Preset" xml:space="preserve">
         <source>XDR Preset</source>
+        <target state="translated">Wstępne ustawienia XDR</target>
         <note/>
       </trans-unit>
       <trans-unit id="XDR Preset &amp; Brightness" xml:space="preserve">
         <source>XDR Preset &amp; Brightness</source>
+        <target state="translated">Wstępne ustawienia XDR i jasność</target>
         <note/>
       </trans-unit>
       <trans-unit id="XDR brightness scale maximum" xml:space="preserve">
@@ -6362,6 +6405,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="a Display" xml:space="preserve">
         <source>a Display</source>
+        <target state="needs-translation"/>
         <note/>
       </trans-unit>
       <trans-unit id="associated" xml:space="preserve">
@@ -6443,30 +6487,37 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="⚠ Associated display mirroring is enforced!" xml:space="preserve">
         <source>⚠ Associated display mirroring is enforced!</source>
+        <target state="translated">⚠ Powiązane klonowanie wyświetlacza jest wymuszone!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Display group layout protection is in effect. This might alter or override the result of a move operation!" xml:space="preserve">
         <source>⚠ Display group layout protection is in effect. This might alter or override the result of a move operation!</source>
+        <target state="translated">⚠ Ochrona układu grupy wyświetlaczy jest włączona. Może to zmienić lub zastąpić wynik operacji przenoszenia!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Image adjustment controls are unavailable." xml:space="preserve">
         <source>⚠ Image adjustment controls are unavailable.</source>
+        <target state="translated">⚠ Sterowanie regulacją obrazu jest niedostępne.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Software XDR upscaling is active for extra brightness while native upscaling is also available. Enable the %@ preset for a better experience!" xml:space="preserve">
         <source>⚠ Software XDR upscaling is active for extra brightness while native upscaling is also available. Enable the %@ preset for a better experience!</source>
+        <target state="translated">⚠ Skalowanie programowe XDR jest aktywne w celu uzyskania dodatkowej jasności, ale dostępne jest również skalowanie natywne. Włącz ustawienie %@, aby uzyskać lepsze wrażenia!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Some adjustments may clip HDR content!" xml:space="preserve">
         <source>⚠ Some adjustments may clip HDR content!</source>
+        <target state="translated">⚠ Niektóre zmiany mogą spowodować przycięcie zawartości HDR!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Stream auto-starts to associated display!" xml:space="preserve">
         <source>⚠ Stream auto-starts to associated display!</source>
+        <target state="translated">⚠ Strumień uruchamia się automatycznie na przypisanym wyświetlaczu!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Virtual Screen as Mirror Target?" xml:space="preserve">
         <source>⚠ Virtual Screen as Mirror Target?</source>
+        <target state="translated">⚠ Wirtualny wyświetlacz jako cel klonowania</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠ Virtual Screen as Stream Target?" xml:space="preserve">
@@ -6477,14 +6528,19 @@ You can dismiss this notification - in this case the changes will be applied whe
         <source>⚠️ An EDID write operation modifies the EDID and DisplayID data on the device itself. Erroneous EDID data or a problem during EDID write might render the display permanently unusable!
 
 Most displays do not allow EDID write for security reasons, some displays require EDID write to be activated in a service menu. Most EDID emulators or pass-thru dongles support EDID write. EDID write (if supported) usually works over HDMI.</source>
+        <target state="translated">⚠️ Operacja zapisu EDID modyfikuje dane EDID i DisplayID w samym urządzeniu. Błędne dane EDID lub problem podczas zapisu EDID może spowodować, że wyświetlacz będzie trwale bezużyteczny!
+
+Większość wyświetlaczy nie zezwala na zapis EDID ze względów bezpieczeństwa, a niektóre wyświetlacze wymagają aktywacji zapisu EDID w menu serwisowym. Większość emulatorów EDID lub kluczy sprzętowych pass-thru obsługuje zapis EDID. Zapis EDID (jeśli jest obsługiwany) zwykle działa przez HDMI.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ An alternate EDID identity is in effect - system configuration changes will be tied to this identity!" xml:space="preserve">
         <source>⚠️ An alternate EDID identity is in effect - system configuration changes will be tied to this identity!</source>
+        <target state="translated">⚠️ Obowiązuje alternatywna tożsamość EDID - zmiany konfiguracji systemu będą powiązane z tą tożsamością!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ EDID data cannot be interpreted (might be invalid)." xml:space="preserve">
         <source>⚠️ EDID data cannot be interpreted (might be invalid).</source>
+        <target state="translated">⚠️ Nie można odczytać danych EDID (mogą być nieprawidłowe).</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ EDID data retrieval failed." xml:space="preserve">
@@ -6494,62 +6550,77 @@ Most displays do not allow EDID write for security reasons, some displays requir
       </trans-unit>
       <trans-unit id="⚠️ EDID operations might not available for the built-in display of this Apple Silicon Mac." xml:space="preserve">
         <source>⚠️ EDID operations might not available for the built-in display of this Apple Silicon Mac.</source>
+        <target state="translated">⚠️ Operacje EDID mogą być niedostępne dla wbudowanego wyświetlacza tego komputera Apple Silicon Mac.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ For best results stick close to the display aspect ratio!" xml:space="preserve">
         <source>⚠️ For best results stick close to the display aspect ratio!</source>
+        <target state="translated">⚠️ Aby uzyskać najlepsze rezultaty, trzymaj się proporcji ekranu!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ For this XDR display it best to set calibration to Default - Auto Calibrate so the app can automatically adapt upscaling to the currently selected XDR preset and environmental factors. For manual calibration set the brightness slider as high as possible while also making sure you still see the smiling face!" xml:space="preserve">
         <source>⚠️ For this XDR display it best to set calibration to Default - Auto Calibrate so the app can automatically adapt upscaling to the currently selected XDR preset and environmental factors. For manual calibration set the brightness slider as high as possible while also making sure you still see the smiling face!</source>
+        <target state="translated">⚠️ W przypadku tego wyświetlacza XDR najlepiej ustawić kalibrację na Domyślna - Automatyczna kalibracja, aby aplikacja mogła automatycznie dostosować skalowanie do aktualnie wybranego ustawienia XDR i czynników środowiskowych. W przypadku kalibracji ręcznej ustaw suwak jasności tak wysoko, jak to możliwe, jednocześnie upewniając się, że nadal widzisz uśmiechniętą twarz!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Full screen streaming is unavailable as it requires Screen Recording permissions. You can grant this under System Settings &gt; Privacy &amp; Security &gt; Screen Recording!" xml:space="preserve">
         <source>⚠️ Full screen streaming is unavailable as it requires Screen Recording permissions. You can grant this under System Settings &gt; Privacy &amp; Security &gt; Screen Recording!</source>
+        <target state="translated">⚠️ Funkcja przesyłania strumieniowego w trybie pełnoekranowym jest niedostępna, ponieważ wymaga uprawnień do nagrywania ekranu. Można je przyznać w Ustawieniach systemu &gt; Prywatność i bezpieczeństwo &gt; Nagrywanie ekranu!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ If a third party app (like MediaMate) is being used to show the OSD, you might want to disable the built-in OSD under Keyboard/OSD to avoid having duplicated or mixed-style OSDs presented!" xml:space="preserve">
         <source>⚠️ If a third party app (like MediaMate) is being used to show the OSD, you might want to disable the built-in OSD under Keyboard/OSD to avoid having duplicated or mixed-style OSDs presented!</source>
+        <target state="translated">⚠️ Jeśli do wyświetlania OSD używana jest aplikacja firmy trzeciej (np. MediaMate), warto wyłączyć wbudowane OSD w Klawiatura/OSD, aby uniknąć wyświetlania zduplikowanych lub mieszanych OSD!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ If you want to mirror/stream the virtual screen to a natively connected display only to get flexible HiDPI resolutions, it is recommended to use the flexible scaling feature instead if possible! If you want to use mirroring instead of streaming, this can be enabled in the app menu once the virtual screen was connected." xml:space="preserve">
         <source>⚠️ If you want to mirror/stream the virtual screen to a natively connected display only to get flexible HiDPI resolutions, it is recommended to use the flexible scaling feature instead if possible! If you want to use mirroring instead of streaming, this can be enabled in the app menu once the virtual screen was connected.</source>
+        <target state="translated">⚠️ Jeśli chcesz klonować/strumieniować wirtualny ekran do natywnie podłączonego wyświetlacza tylko w celu uzyskania elastycznych rozdzielczości HiDPI, zaleca się użycie funkcji elastycznego skalowania, jeśli to możliwe! Jeśli chcesz używać klonowania zamiast przesyłania strumieniowego, można to włączyć w menu aplikacji po podłączeniu wirtualnego ekranu.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ It is recommended to have some more leeway in the range!" xml:space="preserve">
         <source>⚠️ It is recommended to have some more leeway in the range!</source>
+        <target state="translated">⚠️ Zaleca się większą swobodę w tym zakresie!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Layout protection is disabled for this display group." xml:space="preserve">
         <source>⚠️ Layout protection is disabled for this display group.</source>
+        <target state="translated">⚠️ Ochrona układu jest wyłączona dla tej grupy wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Metal performance might be degraded on this device with integrated Intel GPU." xml:space="preserve">
         <source>⚠️ Metal performance might be degraded on this device with integrated Intel GPU.</source>
+        <target state="translated">⚠️ Wydajność Metal może być obniżona na tym urządzeniu ze zintegrowanym procesorem graficznym Intel.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Minimum width/height value should be lower than the maximum!" xml:space="preserve">
         <source>⚠️ Minimum width/height value should be lower than the maximum!</source>
+        <target state="translated">⚠️ Minimalna wartość szerokości/wysokości powinna być niższa niż maksymalna!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Native XDR upscaling is enabled but not in effect - a different XDR preset might have been selected outside of the app. %@ will still attempt to activate native XDR upscaling upon app restart whenever the default XDR preset is selected." xml:space="preserve">
         <source>⚠️ Native XDR upscaling is enabled but not in effect - a different XDR preset might have been selected outside of the app. %@ will still attempt to activate native XDR upscaling upon app restart whenever the default XDR preset is selected.</source>
+        <target state="translated">⚠️ Natywne skalowanie XDR jest włączone, ale nie działa - inne ustawienie XDR mogło zostać wybrane poza aplikacją. %@ będzie nadal próbował aktywować natywne skalowanie XDR po ponownym uruchomieniu aplikacji, gdy wybrane zostanie domyślne ustawienie XDR.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ No display groups are available." xml:space="preserve">
         <source>⚠️ No display groups are available.</source>
+        <target state="translated">⚠️ Żadne grupy wyświetlaczy nie są dostępne.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Notifications are turned off for the app. Fix this under System Settings &gt; Notifications!" xml:space="preserve">
         <source>⚠️ Notifications are turned off for the app. Fix this under System Settings &gt; Notifications!</source>
+        <target state="translated">⚠️ Powiadomienia są wyłączone dla aplikacji. Napraw to w Ustawieniach systemu &gt; Powiadomienia!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Software XDR upscaling is active for extra brightness while native XDR upscaling is also available. It is recommended to enable native XDR brightness upscaling instead for an improved dimming, upscaling and syncing experience!" xml:space="preserve">
         <source>⚠️ Software XDR upscaling is active for extra brightness while native XDR upscaling is also available. It is recommended to enable native XDR brightness upscaling instead for an improved dimming, upscaling and syncing experience!</source>
+        <target state="translated">⚠️ Skalowanie programowe XDR jest aktywne dla dodatkowej jasności, podczas gdy natywne skalowanie XDR jest również dostępne. Zaleca się włączenie natywnego skalowania jasności XDR, aby uzyskać lepsze wrażenia z przyciemniania, skalowania i synchronizacji!</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Synchronization is disabled for this display group." xml:space="preserve">
         <source>⚠️ Synchronization is disabled for this display group.</source>
+        <target state="translated">⚠️ Synchronizacja jest wyłączona dla tej grupy wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ The protection is not in effect unless all participating displays are connected." xml:space="preserve">

--- a/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
+++ b/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
@@ -244,50 +244,62 @@
       </trans-unit>
       <trans-unit id="A controllable display is present" xml:space="preserve">
         <source>A controllable display is present</source>
+        <target state="translated">Dostępny jest sterowalny wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="A display group can cover all displays (with an optionally specified list of exceptions) or may consist of a specific list of displays. Display group membership may determine the activation status of the display group (depending on activation policy settings) and influence how display group based features behave." xml:space="preserve">
         <source>A display group can cover all displays (with an optionally specified list of exceptions) or may consist of a specific list of displays. Display group membership may determine the activation status of the display group (depending on activation policy settings) and influence how display group based features behave.</source>
+        <target state="translated">Grupa wyświetlaczy może obejmować wszystkie wyświetlacze (z opcjonalnie określoną listą wyjątków) lub może składać się z określonej listy wyświetlaczy. Obecność w grupie wyświetlaczy może określać stan aktywacji grupy wyświetlaczy (w zależności od ustawień zasad aktywacji) i wpływać na zachowanie funkcji opartych na grupie wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A display group with the name '%@' already exists." xml:space="preserve">
         <source>A display group with the name '%@' already exists.</source>
+        <target state="translated">Grupa wyświetlania o nazwie „%@” już istnieje.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A display is present which is not fully controllable without the app" xml:space="preserve">
         <source>A display is present which is not fully controllable without the app</source>
+        <target state="translated">Obecny jest wyświetlacz, którym nie można w pełni sterować bez aplikacji</target>
         <note/>
       </trans-unit>
       <trans-unit id="A higher priority display group marked as exclusive is active." xml:space="preserve">
         <source>A higher priority display group marked as exclusive is active.</source>
+        <target state="translated">Aktywna jest grupa wyświetlaczy o wyższym priorytecie oznaczona jako wyłączna.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A less than 720p desktop resolution is not ideal for macOS usability as GUI elements might not fit. This affects virtual screens as well as the resolution slider for displays." xml:space="preserve">
         <source>A less than 720p desktop resolution is not ideal for macOS usability as GUI elements might not fit. This affects virtual screens as well as the resolution slider for displays.</source>
+        <target state="translated">Mniejsza rozdzielczość niż 720p nie jest najlepsza dla macOS, ponieważ niektóre elementy interfejsu użytkownika mogą się nie zmieścić na ekranie. Ma to wpływ na ekrany wirtualne oraz suwak rozdzielczości wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A pop-up notification will appear when the app detects interference from other apps that adjust the color table. Useful for troubleshooting." xml:space="preserve">
         <source>A pop-up notification will appear when the app detects interference from other apps that adjust the color table. Useful for troubleshooting.</source>
+        <target state="translated">Gdy aplikacja wykryje zakłócenia z innych aplikacji, które dostosowują tabelę kolorów, na ekranie pojawi się powiadomienie. Przydatne podczas rozwiązywania problemów.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A virtual screen is similar to a real display but exists only in the virtual space (in the computer's memory). You can use it to show it in a PIP window, stream or mirror its content to a real display or use it as a source for screen recording or screencast via an appropriate app." xml:space="preserve">
         <source>A virtual screen is similar to a real display but exists only in the virtual space (in the computer's memory). You can use it to show it in a PIP window, stream or mirror its content to a real display or use it as a source for screen recording or screencast via an appropriate app.</source>
+        <target state="translated">Wirtualny wyświetlacz jest podobny do prawdziwego ekranu, ale istnieje tylko w przestrzeni wirtualnej (w pamięci komputera). Można go używać do wyświetlania w oknie PIP, przesyłania strumieniowego lub klonowania jego zawartości do rzeczywistego wyświetlacza albo używania go jako źródła do nagrywania ekranu lub screencastu za pomocą odpowiedniej aplikacji.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A virtual screen which is associated with a display will automatically connect or disconnect when the associated display is connected or disconnected. You can disable auto-connect for associated virtual screens." xml:space="preserve">
         <source>A virtual screen which is associated with a display will automatically connect or disconnect when the associated display is connected or disconnected. You can disable auto-connect for associated virtual screens.</source>
+        <target state="translated">Wirtualny wyświetlacz, który jest powiązany z ekranem, zostanie automatycznie podłączony lub odłączony, gdy powiązany ekran zostanie podłączony lub odłączony. Można wyłączyć automatyczne łączenie dla powiązanych wyświetlaczy wirtualnych.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A virtual screen which is associated with a display will automatically connect when the associated display is connected. All other virtual screens were connected. You can disable auto-connect for associated virtual screens." xml:space="preserve">
         <source>A virtual screen which is associated with a display will automatically connect when the associated display is connected. All other virtual screens were connected. You can disable auto-connect for associated virtual screens.</source>
+        <target state="translated">Wirtualny wyświetlacz, który jest powiązany z monitorem, połączy się automatycznie po podłączeniu powiązanego monitora. Wszystkie inne wirtualne wyświetlacze zostały podłączone. Można wyłączyć automatyczne łączenie dla powiązanych wirtualnych wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A virtual screen which is associated with a display will automatically disconnect when the associated display is disconnected. All other virtual screens were disconnected. You can disable auto-disconnect for associated virtual screens." xml:space="preserve">
         <source>A virtual screen which is associated with a display will automatically disconnect when the associated display is disconnected. All other virtual screens were disconnected. You can disable auto-disconnect for associated virtual screens.</source>
+        <target state="translated">Wirtualny wyświetlacz powiązany z monitorem zostanie automatycznie odłączony po odłączeniu powiązanego monitora. Wszystkie inne wirtualne wyświetlacze zostały odłączone. Można wyłączyć automatyczne rozłączanie dla powiązanych wirtualnych wyświetlaczy.</target>
         <note/>
       </trans-unit>
       <trans-unit id="A virtual screen which is associated with a display will connect or disconnect automatically when the associated display is connected or disconnected." xml:space="preserve">
         <source>A virtual screen which is associated with a display will connect or disconnect automatically when the associated display is connected or disconnected.</source>
+        <target state="translated">Wirtualny wyświetlacz, który jest powiązany z monitorem, połączy się lub rozłączy automatycznie, gdy powiązany monitor zostanie podłączony lub odłączony.</target>
         <note/>
       </trans-unit>
       <trans-unit id="About" xml:space="preserve">
@@ -302,30 +314,37 @@
       </trans-unit>
       <trans-unit id="Above %@" xml:space="preserve">
         <source>Above %@</source>
+        <target state="translated">Powyżej %@</target>
         <note/>
       </trans-unit>
       <trans-unit id="Above Menu, Dock, Spaces" xml:space="preserve">
         <source>Above Menu, Dock, Spaces</source>
+        <target state="translated">Powyżej Menu, Docka, Przestrzeni</target>
         <note/>
       </trans-unit>
       <trans-unit id="Accessibility Configuration Required!" xml:space="preserve">
         <source>Accessibility Configuration Required!</source>
+        <target state="translated">Wymagana konfiguracja ułatwień dostępu!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Accessibility Configured - App Restart Needed" xml:space="preserve">
         <source>Accessibility Configured - App Restart Needed</source>
+        <target state="translated">Ułatwienia dostępu skonfigurowane - wymagane ponowne uruchomienie aplikacji</target>
         <note/>
       </trans-unit>
       <trans-unit id="Accessibility Permissions are configured but the **app still needs to be restarted** for the changes to take effect! Please close and restart the app when it is convenient or press the &quot;Restart %@&quot; button below to restart the app immediately!" xml:space="preserve">
         <source>Accessibility Permissions are configured but the **app still needs to be restarted** for the changes to take effect! Please close and restart the app when it is convenient or press the "Restart %@" button below to restart the app immediately!</source>
+        <target state="translated">Uprawnienia dostępności zostały skonfigurowane, ale **aplikacja nadal wymaga ponownego uruchomienia**, aby zmiany zaczęły obowiązywać! Zamknij i uruchom ponownie aplikację, gdy będzie to możliwe, lub naciśnij przycisk „Uruchom ponownie %@” poniżej, aby natychmiast ponownie uruchomić aplikację!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Accessibility Permissions are properly configured. Native (Apple) keyboard brightness and volume keys should work if these features are otherwise set up. If not, please try restarting the app!" xml:space="preserve">
         <source>Accessibility Permissions are properly configured. Native (Apple) keyboard brightness and volume keys should work if these features are otherwise set up. If not, please try restarting the app!</source>
+        <target state="translated">Uprawnienia ułatwień dostępu są prawidłowo skonfigurowane. Natywna (Apple'owska) jasność klawiatury i klawisze głośności powinny działać, jeśli te funkcje są skonfigurowane w inny sposób. Jeśli nie, spróbuj ponownie uruchomić aplikację!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Accessibility is Configured Properly" xml:space="preserve">
         <source>Accessibility is Configured Properly</source>
+        <target state="translated">Ułatwienia dostępu skonfigurowane poprawnie</target>
         <note/>
       </trans-unit>
       <trans-unit id="Activate" xml:space="preserve">
@@ -335,10 +354,12 @@
       </trans-unit>
       <trans-unit id="Activate Configuration Without Reboot?" xml:space="preserve">
         <source>Activate Configuration Without Reboot?</source>
+        <target state="translated">Czy aktywować konfigurację bez ponownego uruchamiania?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Activate this display group when…" xml:space="preserve">
         <source>Activate this display group when…</source>
+        <target state="translated">Aktywuj tę grupę wyświetlania, gdy...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Activated only when the display is not set as main so it does not interfere with the lock screen. Most displays do not support turning the backlight off or back on via DDC." xml:space="preserve">
@@ -347,6 +368,7 @@
       </trans-unit>
       <trans-unit id="Activation" xml:space="preserve">
         <source>Activation</source>
+        <target state="translated">Aktywacja</target>
         <note/>
       </trans-unit>
       <trans-unit id="Activation depends on enabled synchronization, UI scale matching or layout protection for this display group." xml:space="preserve">
@@ -416,6 +438,7 @@
       </trans-unit>
       <trans-unit id="Additional options are available under the display's &quot;Hardware Control&quot; section for this feature." xml:space="preserve">
         <source>Additional options are available under the display's "Hardware Control" section for this feature.</source>
+        <target state="translated">Dodatkowe funkcje dla tej funkcji są dostępne w sekcji wyświetlacza „Sterowanie sprzętem”.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Additional payment methods &amp; licenses:" xml:space="preserve">
@@ -1098,30 +1121,37 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Brightness (Combined, Metal Upscaling)" xml:space="preserve">
         <source>Brightness (Combined, Metal Upscaling)</source>
+        <target state="translated">Jasność (łączna, skalowanie Metal)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Combined, Software Upscaling)" xml:space="preserve">
         <source>Brightness (Combined, Software Upscaling)</source>
+        <target state="translated">Jasność (łączna, skalowanie programowe)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Hardware)" xml:space="preserve">
         <source>Brightness (Hardware)</source>
+        <target state="translated">Jasność (sprzętowa)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Metal Upscaling)" xml:space="preserve">
         <source>Brightness (Metal Upscaling)</source>
+        <target state="translated">Jasność (skalowanie Metal)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Metal)" xml:space="preserve">
         <source>Brightness (Metal)</source>
+        <target state="translated">Jasność (Metal)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Native XDR Upscaling)" xml:space="preserve">
         <source>Brightness (Native XDR Upscaling)</source>
+        <target state="translated">Jasność (skalowanie natywnym XDR)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Software Upscaling)" xml:space="preserve">
         <source>Brightness (Software Upscaling)</source>
+        <target state="translated">Jasność (skalowanie programowe)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness (Software)" xml:space="preserve">
@@ -1280,18 +1310,22 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Combined brightness" xml:space="preserve">
         <source>Combined brightness</source>
+        <target state="translated">Jasność łączna</target>
         <note/>
       </trans-unit>
       <trans-unit id="Combined brightness - XDR/HDR upscaling maximum scale value" xml:space="preserve">
         <source>Combined brightness - XDR/HDR upscaling maximum scale value</source>
+        <target state="translated">Jasność łączna - maksymalna wartość skalowania XDR/HDR</target>
         <note/>
       </trans-unit>
       <trans-unit id="Combined brightness - minimum allowed hardware brightness level" xml:space="preserve">
         <source>Combined brightness - minimum allowed hardware brightness level</source>
+        <target state="translated">Jasność łączna - minimalny dozwolony poziom jasności sprzętowej</target>
         <note/>
       </trans-unit>
       <trans-unit id="Combined brightness - software dimming switchover point" xml:space="preserve">
         <source>Combined brightness - software dimming switchover point</source>
+        <target state="translated">Jasność łączna - punkt przełączania przyciemniania programowego</target>
         <note/>
       </trans-unit>
       <trans-unit id="Combined brightness is not required with default settings as the native XDR brightness scale covers the entire configurable scale. Use only if you want to finetune the dimming curve below the configured XDR brightness scale minimum" xml:space="preserve">
@@ -2041,10 +2075,12 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Discard Virtual Screen" xml:space="preserve">
         <source>Discard Virtual Screen</source>
+        <target state="translated">Odrzuć wirtualny wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="Discard…" xml:space="preserve">
         <source>Discard…</source>
+        <target state="translated">Odrzuć...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Disconnect" xml:space="preserve">
@@ -2231,7 +2267,7 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Display Notch" xml:space="preserve">
         <source>Display Notch</source>
-        <target state="translated">Wyświetl Notch</target>
+        <target state="translated">Wyświetlanie Notcha</target>
         <note/>
       </trans-unit>
       <trans-unit id="Display group is configured to be always active regardless of the presence of group members." xml:space="preserve">
@@ -2252,6 +2288,7 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Display group name" xml:space="preserve">
         <source>Display group name</source>
+        <target state="translated">Nazwa grupy wyświetlaczy</target>
         <note/>
       </trans-unit>
       <trans-unit id="Display group settings will be available at the created group's settings pane." xml:space="preserve">
@@ -2369,11 +2406,12 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Do you want to discard all virtual screens?" xml:space="preserve">
         <source>Do you want to discard all virtual screens?</source>
-        <target state="translated">Czy chcesz odrzucić wszystkie wirtualne ekrany?</target>
+        <target state="translated">Czy chcesz odrzucić wszystkie wirtualne wyświetlacze?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Do you want to discard the virtual screen?" xml:space="preserve">
         <source>Do you want to discard the virtual screen?</source>
+        <target state="translated">Czy chcesz odrzucić wirtualny wyświetlacz?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Do you want to proceed?" xml:space="preserve">
@@ -2461,7 +2499,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Edit system display name" xml:space="preserve">
         <source>Edit system display name</source>
-        <target state="translated">Nazwa wyświetlacza w systemie</target>
+        <target state="translated">Edytuj nazwę wyświetlacza w systemie</target>
         <note/>
       </trans-unit>
       <trans-unit id="Edit the system configuration of this display model" xml:space="preserve">
@@ -2483,6 +2521,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Edited system display name" xml:space="preserve">
         <source>Edited system display name</source>
+        <target state="translated">Edytowana nazwa wyświetlacza w systemie</target>
         <note/>
       </trans-unit>
       <trans-unit id="Enable All Protections" xml:space="preserve">
@@ -2616,6 +2655,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Enabled" xml:space="preserve">
         <source>Enabled</source>
+        <target state="translated">Aktywne</target>
         <note/>
       </trans-unit>
       <trans-unit id="Enables low-level resolution change for mirror targets. Allows Refresh Rate and Color Depth submenus as well." xml:space="preserve">
@@ -2896,6 +2936,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="Groups" xml:space="preserve">
         <source>Groups</source>
+        <target state="translated">Grupy</target>
         <note/>
       </trans-unit>
       <trans-unit id="HDR Color Profile changed for %@." xml:space="preserve">
@@ -3067,7 +3108,7 @@ The process does not work for the built-in display (reboot needed). The operatio
       </trans-unit>
       <trans-unit id="If the display is used as a &quot;Television&quot; (as opposed to &quot;Computer monitor&quot;), it won't be affected by Night Shift and True Tone." xml:space="preserve">
         <source>If the display is used as a "Television" (as opposed to "Computer monitor"), it won't be affected by Night Shift and True Tone.</source>
-        <target state="translated">Jeśli wyświetlacz jest używany jako "telewizor" (w przeciwieństwie do "monitora komputerowego"), Night Shift i True Tone nie będą miały na niego wpływu.</target>
+        <target state="translated">Jeśli wyświetlacz jest używany jako „telewizor” (w przeciwieństwie do „monitora komputerowego"), Night Shift i True Tone nie będą miały na niego wpływu.</target>
         <note/>
       </trans-unit>
       <trans-unit id="If the menu icon is hidden, you can reveal the icon by re-launching the app while the app is already running." xml:space="preserve">
@@ -3717,6 +3758,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Name" xml:space="preserve">
         <source>Name</source>
+        <target state="translated">Nazwa</target>
         <note/>
       </trans-unit>
       <trans-unit id="Native" xml:space="preserve">
@@ -3980,6 +4022,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Overview" xml:space="preserve">
         <source>Overview</source>
+        <target state="translated">Przegląd</target>
         <note/>
       </trans-unit>
       <trans-unit id="Page %lld" xml:space="preserve">
@@ -5461,6 +5504,7 @@ This operation does not reset the display itself.</source>
       </trans-unit>
       <trans-unit id="The default input source list reflects commonly occurring assignments, but the actual list varies by display vendor/model. Try using the &quot;LG alt&quot; toggle for some newer LG displays if input control does not work!" xml:space="preserve">
         <source>The default input source list reflects commonly occurring assignments, but the actual list varies by display vendor/model. Try using the "LG alt" toggle for some newer LG displays if input control does not work!</source>
+        <target state="translated">Domyślna lista źródeł wejściowych odzwierciedla często występujące przypisania, ale rzeczywista lista różni się w zależności od producenta/modelu wyświetlacza. Spróbuj użyć przełącznika „LG alt” dla niektórych nowszych wyświetlaczy LG, jeśli sterowanie wejściem nie działa!</target>
         <note/>
       </trans-unit>
       <trans-unit id="The display group is marked as exclusive while at least one other display group with higher priority is active." xml:space="preserve">
@@ -6134,6 +6178,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="Virtual screen name" xml:space="preserve">
         <source>Virtual screen name</source>
+        <target state="translated">Nazwa wirtualnego wyświetlacza</target>
         <note/>
       </trans-unit>
       <trans-unit id="Virtual screen tag ID" xml:space="preserve">
@@ -6299,7 +6344,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="With this option selected, the app will leave native brightness keys under macOS control if only Apple displays are connected with no additional software brightness control features enabled. In this case however various settings (like &quot;Make fine scale default&quot; or control &quot;All suitable screens&quot; simultaneously) that modify the default behavior of the brightness keys will not apply." xml:space="preserve">
         <source>With this option selected, the app will leave native brightness keys under macOS control if only Apple displays are connected with no additional software brightness control features enabled. In this case however various settings (like "Make fine scale default" or control "All suitable screens" simultaneously) that modify the default behavior of the brightness keys will not apply.</source>
-        <target state="translated">Po wybraniu tej opcji aplikacja pozostawi natywne klawisze jasności pod kontrolą macOS, jeśli podłączone są tylko wyświetlacze Apple bez włączonych dodatkowych funkcji sterowania jasnością oprogramowania. W takim przypadku jednak różne ustawienia (takie jak "Ustaw domyślną dokładną skalę" lub kontroluj "Wszystkie odpowiednie ekrany" jednocześnie), które modyfikują domyślne zachowanie klawiszy jasności, nie będą miały zastosowania.</target>
+        <target state="translated">Po wybraniu tej opcji aplikacja pozostawi natywne klawisze jasności pod kontrolą macOS, jeśli podłączone są tylko wyświetlacze Apple bez włączonych dodatkowych funkcji sterowania jasnością oprogramowania. W takim przypadku jednak różne ustawienia (takie jak „Ustaw domyślną dokładną skalę” lub kontroluj „Wszystkie odpowiednie ekrany" jednocześnie), które modyfikują domyślne zachowanie klawiszy jasności, nie będą miały zastosowania.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Without Screen Recording permissions this feature will not work!" xml:space="preserve">
@@ -6386,6 +6431,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="You can change DDC volume and mute control support for this display under &quot;DDC Features…&quot;." xml:space="preserve">
         <source>You can change DDC volume and mute control support for this display under "DDC Features…".</source>
+        <target state="translated">Obsługę sterowania głośnością i wyciszeniem DDC dla tego wyświetlacza można zmienić w sekcji „Funkcje DDC...”.</target>
         <note/>
       </trans-unit>
       <trans-unit id="You can download the SF Symbols app from [developer.apple.com/sf-symbols](https://developer.apple.com/sf-symbols) to find the right SF Symbol icon string (try: `face.smiling`)." xml:space="preserve">
@@ -6440,7 +6486,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="a Display" xml:space="preserve">
         <source>a Display</source>
-        <target state="needs-translation"/>
+        <target state="translated">Wyświetlacz</target>
         <note/>
       </trans-unit>
       <trans-unit id="associated" xml:space="preserve">
@@ -6557,6 +6603,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="⚠ Virtual Screen as Stream Target?" xml:space="preserve">
         <source>⚠ Virtual Screen as Stream Target?</source>
+        <target state="translated">⚠ Wirtualny wyświetlacz jako cel strumieniowania</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ An EDID write operation modifies the EDID and DisplayID data on the device itself. Erroneous EDID data or a problem during EDID write might render the display permanently unusable!&#10;&#10;Most displays do not allow EDID write for security reasons, some displays require EDID write to be activated in a service menu. Most EDID emulators or pass-thru dongles support EDID write. EDID write (if supported) usually works over HDMI." xml:space="preserve">
@@ -6660,36 +6707,46 @@ Większość wyświetlaczy nie zezwala na zapis EDID ze względów bezpieczeńst
       </trans-unit>
       <trans-unit id="⚠️ The protection is not in effect unless all participating displays are connected." xml:space="preserve">
         <source>⚠️ The protection is not in effect unless all participating displays are connected.</source>
+        <target state="translated">⚠️ Ochrona nie działa, jeśli wszystkie powiązane wyświetlacze nie są podłączone.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ The protection is not in effect unless relative position is defined." xml:space="preserve">
         <source>⚠️ The protection is not in effect unless relative position is defined.</source>
+        <target state="translated">⚠️ Ochrona nie działa, jeśli nie zostanie zdefiniowana pozycja względna.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ This feature is not available in this version." xml:space="preserve">
         <source>⚠️ This feature is not available in this version.</source>
+        <target state="translated">⚠️ Ta funkcja nie jest dostępna w tej wersji.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ This operation might permanently render your display unusable!&#10;&#10;Are sure you want to continue?" xml:space="preserve">
         <source>⚠️ This operation might permanently render your display unusable!
 
 Are sure you want to continue?</source>
+        <target state="translated">⚠️ Ta operacja może trwale uniemożliwić korzystanie z wyświetlacza!
+
+Czy na pewno chcesz kontynuować?</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ This platform (Intel) does not support upscaling when color table adjustments are enabled." xml:space="preserve">
         <source>⚠️ This platform (Intel) does not support upscaling when color table adjustments are enabled.</source>
+        <target state="translated">⚠️ Ta platforma (Intel) nie obsługuje skalowania w górę, gdy włączone są korekty tabeli kolorów.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Unable to enable DDC due to display or connection issues." xml:space="preserve">
         <source>⚠️ Unable to enable DDC due to display or connection issues.</source>
+        <target state="translated">⚠️ Nie można włączyć DDC z powodu problemów z wyświetlaczem lub połączeniem.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Unable to present EDID data." xml:space="preserve">
         <source>⚠️ Unable to present EDID data.</source>
+        <target state="translated">⚠️ Nie można wyświetlić danych EDID.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ Visualization is not indicative as the display is not in the proper orientation for this layout protection configuration!" xml:space="preserve">
         <source>⚠️ Visualization is not indicative as the display is not in the proper orientation for this layout protection configuration!</source>
+        <target state="translated">⚠️ Wizualizacja nie jest reprezentatywna, ponieważ wyświetlacz nie jest ustawiony we właściwej orientacji dla tej konfiguracji ochrony układu!</target>
         <note/>
       </trans-unit>
     </body>
@@ -6705,6 +6762,7 @@ Are sure you want to continue?</source>
       </trans-unit>
       <trans-unit id="CFBundleName" xml:space="preserve">
         <source>BetterDisplayHelper</source>
+        <target state="translated">BetterDisplay (aplikacja pomocnicza)</target>
         <note>Bundle name</note>
       </trans-unit>
       <trans-unit id="NSHumanReadableCopyright" xml:space="preserve">

--- a/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
+++ b/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
@@ -1156,7 +1156,7 @@ Specifying read length is optional - leave the field empty for autodetect.</sour
       </trans-unit>
       <trans-unit id="Brightness (Software)" xml:space="preserve">
         <source>Brightness (Software)</source>
-        <target state="translated">Jasność (oprogramowanie)</target>
+        <target state="translated">Jasność (programowe)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Brightness Keys, Video Adjustment Shortcuts Affect:" xml:space="preserve">

--- a/Localization Glossary Polish.markdown
+++ b/Localization Glossary Polish.markdown
@@ -1,0 +1,313 @@
+# Translation Glossary
+
+In the table below, adjectives have been used in their genderless form, whereas when actually translating, the appropriate genus relating to the noun should be used. Verbs whose person is not specified have been written in the unpersonalized form, whereas when actually translating they should be conjugated with the appropriate form depending on the context.
+
+## Glossary (based on the [Apple Glossar (Polish)](https://developer.apple.com/download/all/?q=glossaries))
+
+The following tables contains the translations used for _BetterDisplay_ from English to Polish.
+### A
+
+| English                   | Polish                                  | Reasoning / Explanation                               |
+| ------------------------- | --------------------------------------- | ----------------------------------------------------- |
+| Accessibility             | Dostępność                              |                                                       |
+| Accessibility Permissions | Uprawnienia do ułatwień dostępu         | Dictionary translation.                               |
+| Activation                | Aktywacja                               |                                                       |
+| Agressive                 | Agresywne                               |                                                       |
+| Ambient light sensor      | Czujnik światła otoczenia               | Translation used on _Apple's_ support page.           |
+| App                       | Aplikacja, Program                      |                                                       |
+| App icon                  | Ikona aplikacji                         |                                                       |
+| Appearance                | Wygląd                                  |                                                       |
+| Application               | Aplikacja                               |                                                       |
+| Apply                     | Zastosować                              |                                                       |
+| Aspect ratio              | Współczynnik proporcji                  |                                                       |
+| Associated                | Powiązane                               |                                                       |
+| Audio Device              | Urządzenie audio                        |                                                       |
+
+### B
+
+| English          | Polish                   | Reasoning / Explanation         |
+| ---------------- | ------------------------ | ------------------------------- |
+| backlight        | podświetlenie            |                                 |
+| Base64 Encoded   | Zakodowane w Base64      |                                 |
+| Basic            | Standardowe, Podstawowe  | Translation depends on context. |
+| build (Software) | kompilacja               |                                 |
+| Built-in         | Wbudowane                |                                 |
+| Button           | Przycisk                 |                                 |
+| By default       | Domyślnie                |                                 |
+
+### C
+
+| English              | Polish                                                      | Reasoning / Explanation                                                                       |
+| -------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Calibrate            | Kalibruj                                                    |                                                                                               |
+| Capabilities         | Właściwości, Funkcje                                        |                                                                                               |
+| Color depth          | Głębia kolorów                                              |                                                                                               |
+| Color table          | Tablica kolorów                                             |                                                                                               |
+| Color profile        | Profil kolorów                                              |                                                                                               |
+| Combined brightness  | Jasność powiązana                                           | Dictionary translation.                                                                       |
+| Connect              | Połączyć, Podłączyć                                         | "Połączyć" is used during wireless connections, while "Podłączyć" is used when using a cable. |
+| Connected (Display)  | Podłączony (Wyświetlacz)                                    | **Uncertain** about using "Monitor" or "Display" for real displays.                           |
+| Continue             | Kontynuować                                                 |                                                                                               |
+| Control**s**         | Sterowanie                                                  |                                                                                               |
+| Create               | Utworzyć                                                    |                                                                                               |
+| Crop areas           | Przyciąć strefy                                             | Dictionary translation.                                                                       |
+| Custom Resolution(s) | Niestandardowa rozdzielczość, Niestandardowe rozdzielczości | Dictionary translation.                                                                       |
+
+### D
+
+| English              | Polish                       | Reasoning / Explanation                                                                                                          |
+| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Dark mode            | Ciemny motyw                 |                                                                                                                                  |
+| Delay                | Opóźnienie                   |                                                                                                                                  |
+| Detachable (menu)    | Odczepiane (menu)            |                                                                                                                                  |
+| Detected             | Wykryte                      |                                                                                                                                  |
+| Dimming              | Przyciemnianie               |                                                                                                                                  |
+| Disabled             | Nieaktywne                   |                                                                                                                                  |
+| Discard              | Odrzucić                     |                                                                                                                                  |
+| Disconnect(ed)       | Odłączyć, Odłączono          |                                                                                                                                  |
+| Dismiss              | Odrzucić                     |                                                                                                                                  |
+| Display              | Wyświetlacz                  | **Uncertain** about using "Monitor" or "Display" for real displays.                                                              |
+| Display group        | Grupa wyświetlaczy           | Dictionary translation.                                                                                                          |
+| Display group member | Element grupy wyświetlaczy   | "Element" is used for technical memberships.                                                                                     |
+| Display mode         | Tryb wyświetlacza            |                                                                                                                                  |
+| Display role         | Rola wyświetlacza            |                                                                                                                                  |
+| Drag                 | Przeciągnij                  |                                                                                                                                  |
+
+### E
+
+| English  | Polish       | Reasoning / Explanation |
+| -------- | ------------ | ----------------------- |
+| Enforce  | Wymuś        |                         |
+| Exclude  | Wykluczyć    |                         |
+| Expanded | Rozwinięte   |                         |
+
+### F
+
+| English               | Polish                              | Reasoning / Explanation |
+| --------------------- | ----------------------------------- | ----------------------- |
+| Factory reset         | Ustawienia fabryczne                |                         |
+| Favorite              | Ulubione                            |                         |
+| Fine-tuning           | Dostrajanie                         | Dictionary translation. |
+| Flexible scaling      | Elastyczne skalowanie               |                         |
+| Framebuffer           | Bufor ramki                         |                         |
+| Freeze                | Zamrozić                            |                         |
+| Full screen streaming | Strumieniowanie pełnoekranowe       | Closest translation.    |
+| Fullscreen            | Pełny ekran                         |                         |
+
+### G
+
+| English      | Polish          | Reasoning / Explanation |
+| ------------ | --------------- | ----------------------- |
+| Gain         | Wzmocnienie     |                         |
+| Gain (color) | Podbicie        | Dictionary translation. |
+| Gamma        | Gamma           |                         |
+| Generic      | Ogólne          |                         |
+| Grayscale    | Skala szarości  |                         |
+
+
+### H
+
+| English     | Polish              | Reasoning / Explanation |
+| ----------- | ------------------- | ----------------------- |
+| Hide        | Ukryj               |                         |
+| Home button | Przycisk początkowy |                         |
+
+### I
+
+| English          | Polish                | Reasoning / Explanation |
+| ---------------- | --------------------- | ----------------------- |
+| Icon             | Ikona                 |                         |
+| icon bounce      | Podskakująca ikona    |                         |
+| Identifiers      | Identyfikatory        |                         |
+| Image adjustment | Dostosowywanie obrazu |                         |
+| Input source     | Źródło                |                         |
+| Interference     | Interferencja         |                         |
+| Invert colors    | Odwrócenie barw       |                         |
+| Item             | Objekt                |                         |
+
+### L
+
+| English       | Polish                              | Reasoning / Explanation                     |
+| ------------- | ----------------------------------- | ------------------------------------------- |
+| Landscape     | Poziome                             |                                             |
+| Liquid Retina | Liquid Retina                       | Translation used on _Apple's_ support page. |
+| Lock Screen   | Ekran blokady                       |                                             |
+| Long press    | Przytrzymanie                       |                                             |
+
+### M
+
+| English         | Polish                        | Reasoning / Explanation |
+| --------------- | ----------------------------- | ----------------------- |
+| Main display    | Wyświetlacz domyślny          |                         |
+| Management      | Zarządzanie                   |                         |
+| Menu bar        | Pasek menu                    |                         |
+| Menu items      | Elementy menu                 |                         |
+| Metal           | Metal                         |                         |
+| Minimize        | Minimalizuj                   |                         |
+| Mirror Displays | Klonowanie wyświetlaczy       |                         |
+| Mirroring       | Klonowanie                    |                         |
+| Mode            | Tryb                          |                         |
+| Mouse pointer   | Kursor myszy                  |                         |
+| Multi-select    | Wielokrotny wybór             |                         |
+| Mute            | Wycisz                        |                         |
+
+### N
+
+| English             | Polish              | Reasoning / Explanation                                     |
+| ------------------- | ------------------- | ----------------------------------------------------------- |
+| Natively connected  | Natywnie połączenie | **Uncertain** about how to translate native, at the moment. |
+| Near-native         | nahe der nativen    | **Uncertain** about how to translate native, at the moment. |
+| Night Shift         | Night Shift         |                                                             |
+| Notch               | Notch               |                                                             |
+| Notifications       | Powiadomienia       |                                                             |
+| Notification center | Centrum powiadomień |                                                             |
+
+### O
+
+| English     | Polish        | Reasoning / Explanation |
+| ----------- | ------------- | ----------------------- |
+| Offset      | Odstęp        |                         |
+| Operation   | Akcja         |                         |
+| Orientation | Orientacja    |                         |
+| Overlay     | Nakładka      |                         |
+| Override    | Nadpisanie    |                         |
+
+
+### P
+
+| English                 | Polish                      | Reasoning / Explanation               |
+| ----------------------- | --------------------------- | ------------------------------------- |
+| Pane (settings context) | Panel (ustawień)            |                                       |
+| pause (to)              | Zatrzymanie lub wznowienie  |                                       |
+| PIP window              | Okno PiP                    |                                       |
+| Portrait                | Pionowe                     |                                       |
+| Power                   | Zasilanie                   | Dictionary translation.               |
+| Power button            | Przycisk zasilania          |                                       |
+| Pre-Release             | Wydanie wstępne             |                                       |
+| Preserve                | Ochrona                     |                                       |
+| Preset                  | Ustawienie wstępne          |                                       |
+| Privacy & Security      | Prywatność i ochrona        |                                       |
+| ProMotion               | ProMotion                   | Used on _Apple's_ Polish product page |
+| Proper                  | Właściwe                    | Dictionary translation.               |
+| Protection              | Ochrona                      |                                       |
+
+### Q
+
+| English      | Polish        | Reasoning / Explanation |
+| ------------ | ------------- | ----------------------- |
+| Quantization | Kwantyzacja   | Dictionary translation. |
+
+
+### R
+
+| English          | Polish                     | Reasoning / Explanation |
+| ---------------- | -------------------------- | ----------------------- |
+| Range            | Zakres                     |                         |
+| Reconnect        | Ponowne po(d)łączenie      |                         |
+| Redo             | Cofnięcie                  |                         |
+| Refresh rate     | Częstotliwość odświeżania  |                         |
+| Required         | Wymagane                   |                         |
+| Resolution       | Rozdzielczość              |                         |
+| Resolution limit | Limit rozdzielczości       | Dictionary translation. |
+| Restart          | Ponowne uruchomienie       |                         |
+| Restore          | Przywrócić                 |                         |
+| Retry            | Spróbować ponownie         |                         |
+| Rotate           | Obrócić                    |                         |
+| Rotation         | Obrót, Rotacja             |                         |
+
+
+### S
+
+| English              | Polish                            | Reasoning / Explanation                                                                                                                                    |
+| -------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Safe mode            | Tryb bezpieczeństwa               |                                                                                                                                                            |
+| Screen Recording     | Nagrywanie ekranu                 |                                                                                                                                                            |
+| Screen saver         | Wygaszacz ekranu                  |                                                                                                                                                            |
+| Scroll gesture       | Gest przewijania                  |                                                                                                                                                            |
+| Selected             | Zaznaczone, wybrane               |                                                                                                                                                            |
+| Set up               | Konfiguracja                      |                                                                                                                                                            |
+| Shift (key)          | Shift                             |                                                                                                                                                            |
+| shortcuts (Keyboard) | Skróty klawiaturowe               | Shortcuts in _Apple_ glossary also refers to _Siri_ shortcuts, or shortcut menus. In _BetterDisplay_ shortcuts are always referring to keyboard shortcuts. |
+| Skip                 | Pominąć                           |                                                                                                                                                            |
+| Sleep                | Uśpić                             |                                                                                                                                                            |
+| Slider               | Suwak                             |                                                                                                                                                            |
+| Smooth               | Płynne                            |                                                                                                                                                            |
+| software dimming     | Jasność programowa                |                                                                                                                                                            |
+| Source Screen        | Wyświetlacz źródłowy              |                                                                                                                                                            |
+| Standby              | Czuwanie, Tryb czuwania           |                                                                                                                                                            |
+| Startup              | Uruchomienie                      |                                                                                                                                                            |
+| Stream               | Strumieniowanie                   |                                                                                                                                                            |
+| String               | Ciąg znaków                       | Dictionary translation.                                                                                                                                    |
+| Swipe gestures       | Gest przesunięcia                 |                                                                                                                                                            |
+| System Settings      | Ustawienia systemowe              |                                                                                                                                                            |
+
+### T
+
+| English     | Polish                          | Reasoning / Explanation |
+| ----------- | ------------------------------- | ----------------------- |
+| Third Party | Inne, Trzecie                   |                         |
+| Toggle      | Przełączyć                      |                         |
+| Toggle Mute | Przełączyć wyciszenie           |                         |
+| Tools       | Narzędzia                       |                         |
+| Transition  | Przejście                       |                         |
+| Trial       | Okres próbny                    |                         |
+| True Tone   | True Tone                       |                         |
+
+### U
+
+| English   | Polish                                      | Reasoning / Explanation |
+| --------- | ------------------------------------------- | ----------------------- |
+| UI        | Interfejs użytkownika                       |                         |
+| Undo      | Cofnąć                                      |                         |
+| Unhide    | Odkryć                                      |                         |
+| Unlock    | Odblokować                                  |                         |
+| Unmute    | Wyłączyć wyciszenie                         |                         |
+| Upgrade   | Zaktualizować                               |                         |
+| Upscaling | Skalowanie                                  | Dictionary translation. |
+
+### V
+
+| English        | Polish                               | Reasoning / Explanation |
+| -------------- | ------------------------------------ | ----------------------- |
+| Virtual screen | Wirtualny wyświetlacz                |                         |
+| Volume control | Sterowanie głośnością                |                         |
+
+### W
+
+| English  | Polish                    | Reasoning / Explanation |
+| -------- | ------------------------- | ----------------------- |
+| Wake     | Wybudzenie                |                         |
+| Wireless | Bezprzewodowy             |                         |
+
+
+
+## Todo list
+
+### Missing translations
+
+| English           | Context                    |
+| ----------------- | -------------------------- |
+| Chiclet           | … OSD Chiclet …            |
+| C style array     | ?                          |
+| CGDirectDisplayID | ?                          |
+| DDC               | ?                          |
+| Dispatch          | ?                          |
+| OSD               | ?                          |
+| skew              | … DDC value mapping skew … |
+| Tag ID            | ?                          |
+| Underscan         | ?                          |
+| XDR               | ?                          |
+
+
+## Check the following, later
+
+| English                   | Polish   |
+| ------------------------- | -------- |
+| environmental factors     |          |
+| notification dispatch     |          |
+| scripted                  |          |
+| dimming                   |          |
+| this is a workaround      | --       |
+| EDID                      | EDID-    |
+| zero software brightness  | --       |
+| notification dispatch     | --       |


### PR DESCRIPTION
Changes include the addition of the most important (i.e., most visible at a glance) translations of the application. It includes probably a full translation of the menu that is accessible from the menu bar, as well as some basic and single words (including "Discard...", "Name" or "Groups").
The quotation marks have also been changed to those used correctly in Polish (from "x" to „x”).
The translation of some strings has been standardized according to the [dictionary](https://github.com/waydabber/BetterDisplay-localization/blob/main/Localization%20Glossary%20Polish.markdown).