### PR TITLE
Removed unnecessary translation of "(Empty string)"

### DIFF
--- a/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
+++ b/BetterDisplay Localizations/pl.xcloc/Localized Contents/pl.xliff
@@ -50,7 +50,7 @@
     <body>
       <trans-unit id="" xml:space="preserve">
         <source/>
-        <target state="translated">(Pusty ciąg znaków)</target>
+        <target state="translated"/>
         <note/>
       </trans-unit>
       <trans-unit id="%" xml:space="preserve">


### PR DESCRIPTION
Hi, the literal translation of "(Empty string)" breaks some parts of the interface and looks awfully. 
![image](https://github.com/user-attachments/assets/4432900d-9ee7-437f-9be2-863ebec369e4)
![image](https://github.com/user-attachments/assets/fd05d4ad-ac16-4918-853e-2eded25a5869)
