### PR TITLE
French localization peer review - fr.xcloc

### DIFF
--- a/BetterDisplay Localizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/BetterDisplay Localizations/fr.xcloc/Localized Contents/fr.xliff
@@ -3993,7 +3993,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Increase display brightness beyond 100%. Requires an Apple XDR display or a HDR capable external display in HDR mode. The feature works with color table adjustments enabled on Apple Silicon Macs or with it disabled (using Metal based overlay brightness control) on all platforms. Upscaling using Metal may increase CPU and GPU usage on some systems." xml:space="preserve">
         <source>Increase display brightness beyond 100%. Requires an Apple XDR display or a HDR capable external display in HDR mode. The feature works with color table adjustments enabled on Apple Silicon Macs or with it disabled (using Metal based overlay brightness control) on all platforms. Upscaling using Metal may increase CPU and GPU usage on some systems.</source>
-        <target state="translated">Augmente la luminosité de l'écran au delà de 100%. Requiert un écran Apple XDR ou un écran externe avec des capacités HDR en mode HDR. Cette fonctionnalité fonctionne avec les ajustements de la palette de couleur activée sur les Macs Apple Silicon ou avec ceux-ci désactivés (en utilisant le contrôle de la luminosité avec une sur-couche Metal) sur toutes les plateformes. La montée en échelle Metal pourrais augmenter la charge processeur (CPU) et carte graphique (GPU) sur certains systèmes.</target>
+        <target state="translated">Augmente la luminosité de l'écran au delà de 100 %. Requiert un écran Apple XDR ou un écran externe avec des capacités HDR en mode HDR. Cette fonctionnalité fonctionne avec les ajustements de la palette de couleur activée sur les Macs Apple Silicon ou avec ceux-ci désactivés (en utilisant le contrôle de la luminosité avec une sur-couche Metal) sur toutes les plateformes. La montée en échelle Metal pourrais augmenter la charge processeur (CPU) et carte graphique (GPU) sur certains systèmes.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Increase gamma" xml:space="preserve">
@@ -4023,7 +4023,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Insert intermediate keyboard/OSD step at neutral 100% for HDR upscaling" xml:space="preserve">
         <source>Insert intermediate keyboard/OSD step at neutral 100% for HDR upscaling</source>
-        <target state="translated">Insert des palier clavier/OSD supplémentaires intermédiaires au 100% neutre de la montée en échelle HDR</target>
+        <target state="translated">Insert des palier clavier/OSD supplémentaires intermédiaires au 100 % neutre de la montée en échelle HDR</target>
         <note/>
       </trans-unit>
       <trans-unit id="Install Display Adaptation…" xml:space="preserve">
@@ -5053,7 +5053,7 @@ Not all displays support DDC power operations. DDC power operations can cause (e
       </trans-unit>
       <trans-unit id="Percentage reflects the size of the GUI elements (Windows, Linux style) instead of the resolution. Native size is 100%. Affects resolution keyboard shortcut as well." xml:space="preserve">
         <source>Percentage reflects the size of the GUI elements (Windows, Linux style) instead of the resolution. Native size is 100%. Affects resolution keyboard shortcut as well.</source>
-        <target state="translated">Le pourcentage reflète la taille des éléments de l'interface graphique (GUI) (style Windows, Linux) à la place de la résolution. La taille native est 100%. Affecte les raccourcis clavier de résolution également.</target>
+        <target state="translated">Le pourcentage reflète la taille des éléments de l'interface graphique (GUI) (style Windows, Linux) à la place de la résolution. La taille native est 100 %. Affecte les raccourcis clavier de résolution également.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Perform VMM7100 HDMI adapter reset" xml:space="preserve">
@@ -7127,7 +7127,7 @@ Please note that previously stored custom display configurations won't be remove
       </trans-unit>
       <trans-unit id="This setting applies to screens/displays that are scalable (virtual screens, real displays with flexible scaling enabled). Default resolution is 100%." xml:space="preserve">
         <source>This setting applies to screens/displays that are scalable (virtual screens, real displays with flexible scaling enabled). Default resolution is 100%.</source>
-        <target state="translated">Ce paramètres s'applique aux écrans qui peuvent êtres mis à l'échelle (écrans virtuels, vrais écrans avec la mise à l'échelle flexible activée). La résolution par défaut est 100%.</target>
+        <target state="translated">Ce paramètres s'applique aux écrans qui peuvent êtres mis à l'échelle (écrans virtuels, vrais écrans avec la mise à l'échelle flexible activée). La résolution par défaut est 100 %.</target>
         <note/>
       </trans-unit>
       <trans-unit id="This should match the physical resolution of the display panel (actual number of pixels vertically and horizontally)." xml:space="preserve">
@@ -7371,17 +7371,17 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="Typical optimal values for contrast are 50%, 70%, 75%, 100%. Make sure you select a value that does not create an issue with white saturation!" xml:space="preserve">
         <source>Typical optimal values for contrast are 50%, 70%, 75%, 100%. Make sure you select a value that does not create an issue with white saturation!</source>
-        <target state="translated">Les valeurs optimales typiques pour le contraste sont 50%, 70%, 75%, 100%. Soyez surs que vous sélectionnez une valeur qui ne pose pas de problème avec la saturation du blanc !</target>
+        <target state="translated">Les valeurs optimales typiques pour le contraste sont 50 %, 70 %, 75 %, 100 %. Soyez surs que vous sélectionnez une valeur qui ne pose pas de problème avec la saturation du blanc !</target>
         <note/>
       </trans-unit>
       <trans-unit id="Typical setting is 100% but some displays prefer 50%." xml:space="preserve">
         <source>Typical setting is 100% but some displays prefer 50%.</source>
-        <target state="translated">Le paramètre typique est 100% mais certains écrans préfère 50%.</target>
+        <target state="translated">Le paramètre typique est 100 % mais certains écrans préfèrent 50 %.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Typical value is 100%." xml:space="preserve">
         <source>Typical value is 100%.</source>
-        <target state="translated">La valeur typique est 100%</target>
+        <target state="translated">La valeur typique est 100 %</target>
         <note/>
       </trans-unit>
       <trans-unit id="Typical values include: 100, 200 or 255 (note: 255 works for most old DDC compatible Apple Cinema / LED displays and helps avoid permanent dimming issue)." xml:space="preserve">
@@ -7840,7 +7840,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="When HDR upscaling is enabled while hardware brightness control is disabled, the app uses a continuous brightness scale between zero and the calibrated max upscale value. Due to this the neutral setting (100% brightness, when on-screen HDR content is unclipped) might not fall to an OSD chiclet boundary which makes it difficult to attain via the shortcut keys. To fix this an additional mid-chiclet step at 100% brightness is inserted." xml:space="preserve">
         <source>When HDR upscaling is enabled while hardware brightness control is disabled, the app uses a continuous brightness scale between zero and the calibrated max upscale value. Due to this the neutral setting (100% brightness, when on-screen HDR content is unclipped) might not fall to an OSD chiclet boundary which makes it difficult to attain via the shortcut keys. To fix this an additional mid-chiclet step at 100% brightness is inserted.</source>
-        <target state="translated">Quand montée en échelle HDR est activée alors que le contrôle matériel de la luminosité est désactivé, l'application utilise un échelle de luminosité continue entre zéro et la valeur maximale calibrée de la montée en échelle. Due à cela le paramètre neutre (100% de luminosité, quand le contenu HDR à l'écran est non-tronqué) pourrais ne pas tomber dans les limites des graduation de l'OSD le rendant difficile à atteindre via les raccourcis claviers. Pour fixer cela une demi-gradation est insérée a 100% de la luminosité est insérée.</target>
+        <target state="translated">Quand montée en échelle HDR est activée alors que le contrôle matériel de la luminosité est désactivé, l'application utilise une échelle de luminosité continue entre zéro et la valeur maximale calibrée de la montée en échelle. À cause du paramètre neutre (100 % de luminosité, quand le contenu HDR à l'écran est non-tronqué) pourrais ne pas tomber dans les limites des graduation de l'OSD le rendant difficile à atteindre via les raccourcis claviers. Pour fixer cela une demi-gradation est insérée a 100 % de la luminosité est insérée.</target>
         <note/>
       </trans-unit>
       <trans-unit id="When Settings is Open" xml:space="preserve">
@@ -7860,7 +7860,7 @@ You can dismiss this notification - in this case the changes will be applied whe
       </trans-unit>
       <trans-unit id="When the display is set as main, the lower limit is 30% for combined or software brightness, 10% for Apple hardware brightness, 0% for DDC hardware brightness." xml:space="preserve">
         <source>When the display is set as main, the lower limit is 30% for combined or software brightness, 10% for Apple hardware brightness, 0% for DDC hardware brightness.</source>
-        <target state="translated">Quand l'écran est définis comme écran principale, la limite basse pour la luminosité combinée ou la luminosité logicielle est à 30%, 10% pour la luminosité matérielle Apple et 0% pour la luminosité matérielle DDC.</target>
+        <target state="translated">Quand l'écran est définis comme écran principale, la limite basse pour la luminosité combinée ou la luminosité logicielle est à 30 %, 10 % pour la luminosité matérielle Apple et 0 % pour la luminosité matérielle DDC.</target>
         <note/>
       </trans-unit>
       <trans-unit id="When this is enabled, syncing won't affect displays in HDR mode or XDR displays set to a reference XDR preset." xml:space="preserve">


### PR DESCRIPTION
Mostly fixed '%' usage. In French, the percentage sign is preceded by a non-breaking space.
100% vs 100 %
https://github.com/waydabber/BetterDisplay-localization/issues/5