### PR TITLE
localisation(de): Add and update German translations in de.xliff

### DIFF
--- a/BetterDisplay Localizations/de.xcloc/Localized Contents/de.xliff
+++ b/BetterDisplay Localizations/de.xcloc/Localized Contents/de.xliff
@@ -27,6 +27,7 @@
       </trans-unit>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>This app needs local network access when its integration features are configured accordingly.</source>
+        <target state="translated">Die App benötigt Zugriff auf das lokale Netzwerk, wenn die Integrationsfunktionen entsprechend konfiguriert sind.</target>
         <note>Privacy - Local Network Usage Description</note>
       </trans-unit>
     </body>
@@ -103,7 +104,7 @@
       </trans-unit>
       <trans-unit id="%@ Certain displays are set to hide the menu bar icon, which may override this setting." xml:space="preserve">
         <source>%@ Certain displays are set to hide the menu bar icon, which may override this setting.</source>
-        <target state="translated">%@ Einige Bildschirme sind so eingestellt, dass sie das Menüleistensymbol ausblenden, was diese Einstellung überschreiben kann.</target>
+        <target state="translated">%@ Einige Displays sind so eingestellt, dass sie das Menüleistensymbol ausblenden, was diese Einstellung überschreiben kann.</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ Configuration Protection can make color mode changes persistent." xml:space="preserve">
@@ -363,6 +364,7 @@
       </trans-unit>
       <trans-unit id="(override)" xml:space="preserve">
         <source>(override)</source>
+        <target state="translated">(überschreiben)</target>
         <note/>
       </trans-unit>
       <trans-unit id="**%@ License Issue Detected**&#10;&#10;This installation has been remotely deactivated, or the hardware identifiers have changed since the last license activation. This may have occurred due to a hardware upgrade or migration to a new device.&#10;&#10;Please reactivate this installation to continue using Pro features." xml:space="preserve">
@@ -385,6 +387,7 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="0.5x" xml:space="preserve">
         <source>0.5x</source>
+        <target state="translated">0.5x</target>
         <note/>
       </trans-unit>
       <trans-unit id="0°" xml:space="preserve">
@@ -394,10 +397,12 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="1.0x" xml:space="preserve">
         <source>1.0x</source>
+        <target state="translated">1.0x</target>
         <note/>
       </trans-unit>
       <trans-unit id="1.5x" xml:space="preserve">
         <source>1.5x</source>
+        <target state="translated">1.5x</target>
         <note/>
       </trans-unit>
       <trans-unit id="1:1 Pixel Mapping" xml:space="preserve">
@@ -412,10 +417,12 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="2.0x" xml:space="preserve">
         <source>2.0x</source>
+        <target state="translated">2.0x</target>
         <note/>
       </trans-unit>
       <trans-unit id="2.5x" xml:space="preserve">
         <source>2.5x</source>
+        <target state="translated">2.5x</target>
         <note/>
       </trans-unit>
       <trans-unit id="4:2:0" xml:space="preserve">
@@ -570,6 +577,7 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Action" xml:space="preserve">
         <source>Action</source>
+        <target state="translated">Aktion</target>
         <note/>
       </trans-unit>
       <trans-unit id="Activate" xml:space="preserve">
@@ -614,14 +622,17 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Add Control…" xml:space="preserve">
         <source>Add Control…</source>
+        <target state="translated">Steuerelement hinzufügen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add Custom Control" xml:space="preserve">
         <source>Add Custom Control</source>
+        <target state="translated">Benutzerdefiniertes Steuerelement hinzufügen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add Custom Feature…" xml:space="preserve">
         <source>Add Custom Feature…</source>
+        <target state="translated">Benutzerdefinierte Funktion hinzufügen…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add Custom Resolution" xml:space="preserve">
@@ -631,10 +642,12 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Add Filter Window Configuration" xml:space="preserve">
         <source>Add Filter Window Configuration</source>
+        <target state="translated">Filterfenster-Konfiguration hinzufügen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add New Custom Control…" xml:space="preserve">
         <source>Add New Custom Control…</source>
+        <target state="translated">Neues benutzerdefiniertes Steuerelement hinzufügen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add New Protection…" xml:space="preserve">
@@ -654,6 +667,7 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Add Parameter…" xml:space="preserve">
         <source>Add Parameter…</source>
+        <target state="translated">Parameter hinzufügen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add Refresh Rate" xml:space="preserve">
@@ -683,14 +697,17 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Adding a control feature" xml:space="preserve">
         <source>Adding a control feature</source>
+        <target state="translated">Steuerfunktion hinzufügen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Adding a custom DDC control" xml:space="preserve">
         <source>Adding a custom DDC control</source>
+        <target state="translated">Benutzerdefiniertes DDC-Steuerelement hinzufügen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Additional Settings…" xml:space="preserve">
         <source>Additional Settings…</source>
+        <target state="translated">Zusätzliche Einstellungen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Additional delay after wake to reapply DDC settings" xml:space="preserve">
@@ -760,7 +777,7 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Adjust the offset of the two displays by modifying the anchor points. Layout protection tries to arrange the displays so they line up at the defined anchor points horizontally or vertically. The default setting is to line up displays in a centered way." xml:space="preserve">
         <source>Adjust the offset of the two displays by modifying the anchor points. Layout protection tries to arrange the displays so they line up at the defined anchor points horizontally or vertically. The default setting is to line up displays in a centered way.</source>
-        <target state="translated">Passe den Versatz der beiden Displays an, indem du die Ankerpunkte änderst. Der Layoutschutz versucht, die Displays so anzuordnen, dass sie an den definierten Ankerpunkten horizontal oder vertikal aufgereiht sind. Die Standardeinstellung ist, dass die Displays zentriert angeordnet werden.</target>
+        <target state="translated">Passe den Versatz der beiden Bildschirme an, indem du die Ankerpunkte änderst. Der Layoutschutz versucht, die Bildschirme so anzuordnen, dass sie an den definierten Ankerpunkten horizontal oder vertikal aufgereiht sind. Die Standardeinstellung ist, dass die Bildschirme zentriert angeordnet werden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Advanced control settings" xml:space="preserve">
@@ -790,7 +807,7 @@ Bitte reaktivieren Sie diese Installation, um die Pro-Funktionen weiterhin nutze
       </trans-unit>
       <trans-unit id="Affected displays" xml:space="preserve">
         <source>Affected displays</source>
-        <target state="translated">Betroffene Displays</target>
+        <target state="translated">Betroffene Bildschirme</target>
         <note/>
       </trans-unit>
       <trans-unit id="After discarding a virtual screen, it is recommended to remove its unused factory color profile as well.&#10;&#10;You can do this in System Settings or the app can do it for you (administrator credentials needed)." xml:space="preserve">
@@ -899,6 +916,7 @@ Dies kann in den Systemeinstellungen gemacht werden oder die App kann es für di
       </trans-unit>
       <trans-unit id="Allow hardware brightness control in HDR mode" xml:space="preserve">
         <source>Allow hardware brightness control in HDR mode</source>
+        <target state="translated">Hardware-Helligkeitskontrolle im HDR-Modus erlauben</target>
         <note/>
       </trans-unit>
       <trans-unit id="Allow native XDR upscaling" xml:space="preserve">
@@ -928,6 +946,7 @@ Dies kann in den Systemeinstellungen gemacht werden oder die App kann es für di
       </trans-unit>
       <trans-unit id="Allow the control to be configured for synchronization for groups." xml:space="preserve">
         <source>Allow the control to be configured for synchronization for groups.</source>
+        <target state="translated">Das Konfigurieren der Steuerung für die Synchronisierung von Gruppen erlauben.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Allow using F14/F15 as alternative brightness keys" xml:space="preserve">
@@ -1229,6 +1248,7 @@ AliPay ist verfügbar in China.</target>
       </trans-unit>
       <trans-unit id="Are you sure you want the app to reset macOS display settings? After reset the system will reboot!" xml:space="preserve">
         <source>Are you sure you want the app to reset macOS display settings? After reset the system will reboot!</source>
+        <target state="translated">Bist du sicher, dass die App die macOS-Anzeigeeinstellungen zurücksetzen soll? Nach dem Zurücksetzen wird das System neu gestartet!“</target>
         <note/>
       </trans-unit>
       <trans-unit id="Are you sure you want to discard this display group and all its settings?" xml:space="preserve">
@@ -1258,6 +1278,7 @@ AliPay ist verfügbar in China.</target>
       </trans-unit>
       <trans-unit id="Are you sure you want to reset (forget) all settings related to all displays?" xml:space="preserve">
         <source>Are you sure you want to reset (forget) all settings related to all displays?</source>
+        <target state="translated">Bist du sicher, dass du alle Einstellungen für alle Displays zurücksetzen (vergessen) möchtest?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Are you sure you want to reset (forget) all settings related to this display? Reset does not affect system configuration settings like flexible scaling, custom resolutions." xml:space="preserve">
@@ -1501,10 +1522,12 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Back to Control Integration Configuration…" xml:space="preserve">
         <source>Back to Control Integration Configuration…</source>
+        <target state="translated">Zurück zur Konfiguration der Steuerungsintegration…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Back to DDC Controls…" xml:space="preserve">
         <source>Back to DDC Controls…</source>
+        <target state="translated">Zurück zu den DDC-Steuerelementen…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Base64 Encoded EDID" xml:space="preserve">
@@ -1848,6 +1871,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Can be used to refer to the custom control via CLI. Must be unique and not clash with predefined controls either." xml:space="preserve">
         <source>Can be used to refer to the custom control via CLI. Must be unique and not clash with predefined controls either.</source>
+        <target state="translated">Kann verwendet werden, um über die CLI auf die benutzerdefinierte Steuerung zuzugreifen. Muss eindeutig sein und darf nicht mit vorgegebenen Steuerungen kollidieren.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cancel" xml:space="preserve">
@@ -1867,6 +1891,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Certain displays (typically those utilizing a backlight technology) produce a more natural image when the gamma is subtly adjusted on software dimming - this gives the image a better contrast." xml:space="preserve">
         <source>Certain displays (typically those utilizing a backlight technology) produce a more natural image when the gamma is subtly adjusted on software dimming - this gives the image a better contrast.</source>
+        <target state="translated">Bestimmte Displays (typischerweise mit Hintergrundbeleuchtung) erzeugen ein natürlicheres Bild, wenn die Gamma-Werte durch Software-Dimmung feinjustiert werden – das verbessert den Bildkontrast.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Change ${rangedFeature} of ${displayEntity} to value ${valueParameter}." xml:space="preserve">
@@ -2119,6 +2144,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Command control" xml:space="preserve">
         <source>Command control</source>
+        <target state="translated">Befehlssteuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Compresses the allowed software brightness range between the specified value and 100%, affecting the software component of combined brightness control as well. This helps avoid accidentally setting the software brightness level too low or to zero." xml:space="preserve">
@@ -2163,6 +2189,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Configure Controls…" xml:space="preserve">
         <source>Configure Controls…</source>
+        <target state="translated">Steuerungen konfigueren...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Configure Custom EDID" xml:space="preserve">
@@ -2177,6 +2204,8 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Configure DDC volume and mute control support under &quot;DDC Controls…&quot; or set up an alternative control method using control integration." xml:space="preserve">
         <source>Configure DDC volume and mute control support under "DDC Controls…" or set up an alternative control method using control integration.</source>
+        <target state="translated">DDC-Lautstärke- und Stummschaltungssteuerung unter „DDC-Steuerungen…“ konfigurieren oder eine alternative Steuerungsmethode über die Steuerungsintegration einrichten.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="Configure Display…" xml:space="preserve">
@@ -2191,6 +2220,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Configure Integration Controls…" xml:space="preserve">
         <source>Configure Integration Controls…</source>
+        <target state="translated">Integrationssteuerungen konfigurieren...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Configure Virtual Screen…" xml:space="preserve">
@@ -2225,6 +2255,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Configure steps for range-based controls" xml:space="preserve">
         <source>Configure steps for range-based controls</source>
+        <target state="translated">Schritte für bereichsbasierte Steuerungen konfigurieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Configure the custom EDID for a display." xml:space="preserve">
@@ -2354,6 +2385,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Content" xml:space="preserve">
         <source>Content</source>
+        <target state="translated">Inhalt</target>
         <note/>
       </trans-unit>
       <trans-unit id="Continuous software XDR upscaling readiness" xml:space="preserve">
@@ -2378,10 +2410,12 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Control integration" xml:space="preserve">
         <source>Control integration</source>
+        <target state="translated">Steuerungsintegration</target>
         <note/>
       </trans-unit>
       <trans-unit id="Control name" xml:space="preserve">
         <source>Control name</source>
+        <target state="translated">Name der Steuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Copy" xml:space="preserve">
@@ -2426,6 +2460,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Create a new" xml:space="preserve">
         <source>Create a new</source>
+        <target state="translated">Neu erstellen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Create a virtual screen that matches to the aspect ratio of another display and associate the virtual screen with the display. Best for a scenario when the virtual screen should be streamed (e.g. portrait Sidecar) or mirrored to a display." xml:space="preserve">
@@ -2490,6 +2525,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Crystallize" xml:space="preserve">
         <source>Crystallize</source>
+        <target state="translated">Kristallisieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Current" xml:space="preserve">
@@ -2574,14 +2610,17 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Custom" xml:space="preserve">
         <source>Custom</source>
+        <target state="translated">Benutzerdefiniert</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom Controls" xml:space="preserve">
         <source>Custom Controls</source>
+        <target state="translated">Benutzerdefinierte Steuerungen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom Controls…" xml:space="preserve">
         <source>Custom Controls…</source>
+        <target state="translated">Benutzerdefinierte Steuerungen…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom Keyboard Shortcuts" xml:space="preserve">
@@ -2601,14 +2640,17 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Custom control icon" xml:space="preserve">
         <source>Custom control icon</source>
+        <target state="translated">Benutzerdefiniertes Steuerungssymbol</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom controls can be assigned to custom DDC, CLI or network based features for various devices and can be used for syncing with display groups." xml:space="preserve">
         <source>Custom controls can be assigned to custom DDC, CLI or network based features for various devices and can be used for syncing with display groups.</source>
+        <target state="translated">Benutzerdefinierte Steuerungen können benutzerdefinierten DDC-, CLI- oder netzwerkbasierten Funktionen für verschiedene Geräte zugewiesen werden und für die Synchronisierung von Anzeigengruppen verwendet werden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom controls can be assigned to custom DDC, CLI or network based features for various devices and can be used for syncing with display groups. Hold ⌥ Option when opening to show predefined controls." xml:space="preserve">
         <source>Custom controls can be assigned to custom DDC, CLI or network based features for various devices and can be used for syncing with display groups. Hold ⌥ Option when opening to show predefined controls.</source>
+        <target state="translated">Benutzerdefinierte Steuerungen können benutzerdefinierten DDC-, CLI- oder netzwerkbasierten Funktionen für verschiedene Geräte zugewiesen werden und für die Synchronisierung von Anzeigengruppen verwendet werden. Halten Sie die ⌥ Optionstaste gedrückt, um vorgegebene Steuerungen anzuzeigen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom display groups require Pro." xml:space="preserve">
@@ -2658,6 +2700,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Customize Blend Mode" xml:space="preserve">
         <source>Customize Blend Mode</source>
+        <target state="translated">Mischmodus anpassen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Customize Menu Options" xml:space="preserve">
@@ -2682,6 +2725,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Customized control via CLI and scripted commands, network or macOS notification dispatch mechanism." xml:space="preserve">
         <source>Customized control via CLI and scripted commands, network or macOS notification dispatch mechanism.</source>
+        <target state="translated">Angepasste Steuerung über CLI- und Skriptbefehle, Netzwerk- oder macOS-Benachrichtigungsmechanismus.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cut" xml:space="preserve">
@@ -2761,6 +2805,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="DDC data" xml:space="preserve">
         <source>DDC data</source>
+        <target state="translated">DDC-Daten</target>
         <note/>
       </trans-unit>
       <trans-unit id="DDC data for the OFF value" xml:space="preserve">
@@ -2929,6 +2974,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Defines how many logical steps the entire range is divided into. By default, it matches the number of fine steps available in the native macOS OSD (64)." xml:space="preserve">
         <source>Defines how many logical steps the entire range is divided into. By default, it matches the number of fine steps available in the native macOS OSD (64).</source>
+        <target state="translated">Legt fest, in wie viele logische Schritte der gesamte Wertebereich unterteilt wird. Standardmäßig entspricht dies der Anzahl an Feinabstufungen im nativen macOS-OSD (64).</target>
         <note/>
       </trans-unit>
       <trans-unit id="Defines the TCP port the built-in HTTP server listens to." xml:space="preserve">
@@ -2948,10 +2994,12 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Defines the number of logical steps in a fine adjustment step. By default, this equals one-quarter of a chiclet in the native macOS OSD (1 logical step)." xml:space="preserve">
         <source>Defines the number of logical steps in a fine adjustment step. By default, this equals one-quarter of a chiclet in the native macOS OSD (1 logical step).</source>
+        <target state="translated">Legt fest, wie viele logische Schritte eine Feinanpassung umfasst. Standardmäßig entspricht dies einem Viertel eines „Chiclets“ im nativen macOS-OSD (1 logischer Schritt).</target>
         <note/>
       </trans-unit>
       <trans-unit id="Defines the number of logical steps in a standard adjustment step. By default, this equals one full chiclet of the native macOS OSD (4 steps per chiclet; 16 chiclets × 4 steps = 64 total steps)." xml:space="preserve">
         <source>Defines the number of logical steps in a standard adjustment step. By default, this equals one full chiclet of the native macOS OSD (4 steps per chiclet; 16 chiclets × 4 steps = 64 total steps).</source>
+        <target state="translated">Legt fest, wie viele logische Schritte eine Standardanpassung umfasst. Standardmäßig entspricht dies einem vollständigen Chiclet im nativen macOS-OSD (4 Schritte pro Chiclet; 16 Chiclets × 4 Schritte = 64 Gesamtschritte).</target>
         <note/>
       </trans-unit>
       <trans-unit id="Defines the upper bound of brightness control in nits. Use 1000 for only allowing up to sustained full screen brightness." xml:space="preserve">
@@ -2971,14 +3019,17 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Delete" xml:space="preserve">
         <source>Delete</source>
+        <target state="translated">Löschen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete Control…" xml:space="preserve">
         <source>Delete Control…</source>
+        <target state="translated">Steuerung löschen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete Custom Control?" xml:space="preserve">
         <source>Delete Custom Control?</source>
+        <target state="translated">Benutzerdefinierte Steuerung löschen?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete Data" xml:space="preserve">
@@ -3038,6 +3089,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Device specific features can be configured and bound to predefined or custom controls configured under Displays &gt; Overview &gt; Custom Controls." xml:space="preserve">
         <source>Device specific features can be configured and bound to predefined or custom controls configured under Displays &gt; Overview &gt; Custom Controls.</source>
+        <target state="translated">Gerätespezifische Funktionen können vorgegebenen oder benutzerdefinierten Steuerungen zugewiesen werden, die unter Displays &gt; Übersicht &gt; Benutzerdefinierte Steuerungen konfiguriert sind.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Device type" xml:space="preserve">
@@ -3457,6 +3509,7 @@ Die Angabe der Leselänge ist optional - lass das Feld leer für automatische Er
       </trans-unit>
       <trans-unit id="Display specific custom DDC features can be configured and bound to custom controls configured under Displays &gt; Overview &gt; Custom Controls." xml:space="preserve">
         <source>Display specific custom DDC features can be configured and bound to custom controls configured under Displays &gt; Overview &gt; Custom Controls.</source>
+        <target state="translated">Anzeigespezifische benutzerdefinierte DDC-Funktionen können benutzerdefinierten Steuerungen zugewiesen werden, die unter Displays &gt; Übersicht &gt; Benutzerdefinierte Steuerungen konfiguriert sind.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Display status" xml:space="preserve">
@@ -3535,6 +3588,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Do nothing" xml:space="preserve">
         <source>Do nothing</source>
+        <target state="translated">Nichts tun</target>
         <note/>
       </trans-unit>
       <trans-unit id="Do you want to deactivate the license?" xml:space="preserve">
@@ -3646,6 +3700,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Edit Settings…" xml:space="preserve">
         <source>Edit Settings…</source>
+        <target state="translated">Einstellungen bearbeiten...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Edit default resolution" xml:space="preserve">
@@ -3755,6 +3810,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Enable Video Filter Window" xml:space="preserve">
         <source>Enable Video Filter Window</source>
+        <target state="translated">Videofilter-Fenster aktivieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Enable color table adjustments" xml:space="preserve">
@@ -3799,6 +3855,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Enable integration features" xml:space="preserve">
         <source>Enable integration features</source>
+        <target state="translated">Integrationsfunktionen aktivieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Enable layout protection" xml:space="preserve">
@@ -3908,6 +3965,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Exclude PIP Window" xml:space="preserve">
         <source>Exclude PIP Window</source>
+        <target state="translated">PIP-Fenster ausschließen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Exclude some displays from the group" xml:space="preserve">
@@ -3977,6 +4035,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Exposure" xml:space="preserve">
         <source>Exposure</source>
+        <target state="translated">Belichtung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Extra wait time after failure" xml:space="preserve">
@@ -4031,6 +4090,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Fine step size" xml:space="preserve">
         <source>Fine step size</source>
+        <target state="translated">Feinschrittgröße</target>
         <note/>
       </trans-unit>
       <trans-unit id="First added" xml:space="preserve">
@@ -4070,6 +4130,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="For features that trigger a feature or functionality." xml:space="preserve">
         <source>For features that trigger a feature or functionality.</source>
+        <target state="translated">Für Funktionen, die eine andere Funktion oder ein Feature auslösen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Force support for color table adjustments" xml:space="preserve">
@@ -4094,10 +4155,12 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Forget All Displays" xml:space="preserve">
         <source>Forget All Displays</source>
+        <target state="translated">Alle Displays vergessen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Forget All Displays…" xml:space="preserve">
         <source>Forget All Displays…</source>
+        <target state="translated">Vergiss alle Displays…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Forget Display" xml:space="preserve">
@@ -4300,6 +4363,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Group synchronization" xml:space="preserve">
         <source>Group synchronization</source>
+        <target state="translated">Gruppensynchronisierung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Groups" xml:space="preserve">
@@ -4368,6 +4432,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Hardware &amp; Integration Control" xml:space="preserve">
         <source>Hardware &amp; Integration Control</source>
+        <target state="translated">Hardware- &amp; Integrationssteuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hardware Control" xml:space="preserve">
@@ -4377,10 +4442,12 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Hardware Control &amp; Integration" xml:space="preserve">
         <source>Hardware Control &amp; Integration</source>
+        <target state="translated">Hardware-Steuerung &amp; Integration</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hardware control &amp; integration settings" xml:space="preserve">
         <source>Hardware control &amp; integration settings</source>
+        <target state="translated">Hardware-Steuerung &amp; Integrations-Einstellungen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hardware control (Apple)" xml:space="preserve">
@@ -4448,7 +4515,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Hide menu bar icon when no other displays are present" xml:space="preserve">
         <source>Hide menu bar icon when no other displays are present</source>
-        <target state="translated">Menüleistensymbol ausblenden, wenn keine anderen Bildschirme vorhanden sind</target>
+        <target state="translated">Menüleistensymbol ausblenden, wenn keine anderen Displays vorhanden sind</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hide other unexpanded menu items" xml:space="preserve">
@@ -4467,11 +4534,12 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="Hold ⇧ Shift during app startup to engage safe mode and prevent writing saved value." xml:space="preserve">
         <source>Hold ⇧ Shift during app startup to engage safe mode and prevent writing saved value.</source>
+        <target state="translated">Halten Sie beim Starten der App die ⇧ Shift-Taste gedrückt, um den abgesicherten Modus zu aktivieren und das Speichern von Werten zu verhindern.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hold ⇧ Shift during app startup to engage safe mode and prevent writing saved value. With combined control enabled, DDC brightness might be reapplied even when unselected." xml:space="preserve">
         <source>Hold ⇧ Shift during app startup to engage safe mode and prevent writing saved value. With combined control enabled, DDC brightness might be reapplied even when unselected.</source>
-        <target state="translated">Halte die ⇧ Umschalttaste, während des Starts der App, gedrückt um den gesicherten Modus zu aktivieren und zu verhindern, dass Werte gespeichert werden. Wenn die kombinierte Kontrolle aktiviert ist, die DDC Helligkeit kann eventuell angewendet werden, auch wenn es nicht ausgewählt ist.</target>
+        <target state="translated">Halte die ⇧ Umschalttaste, während des Starts der App, gedrückt um den gesicherten Modus zu aktivieren und zu verhindern, dass Werte gespeichert werden. Wenn die kombinierte Kontrolle aktiviert ist, die DDC-Helligkeit kann eventuell angewendet werden, auch wenn es nicht ausgewählt ist.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hold ⇧ Shift for multi-select." xml:space="preserve">
@@ -4574,6 +4642,7 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="If read is configured." xml:space="preserve">
         <source>If read is configured.</source>
+        <target state="translated">Wenn das Lesen konfiguriert ist.</target>
         <note/>
       </trans-unit>
       <trans-unit id="If source and target control ranges differ, synchronized values are remapped (rebased) accordingly." xml:space="preserve">
@@ -4583,10 +4652,12 @@ Dieser Vorgang kann nicht auf das integrierte Display angewendet werden (Neustar
       </trans-unit>
       <trans-unit id="If specified, this regex is performed on the combined output to extract the return value." xml:space="preserve">
         <source>If specified, this regex is performed on the combined output to extract the return value.</source>
+        <target state="translated">Falls angegeben, wird dieser reguläre Ausdruck auf die kombinierte Ausgabe angewendet, um den Rückgabewert zu extrahieren.</target>
         <note/>
       </trans-unit>
       <trans-unit id="If specified, this regex is performed on the response to extract the return value." xml:space="preserve">
         <source>If specified, this regex is performed on the response to extract the return value.</source>
+        <target state="translated">Falls angegeben, wird dieser reguläre Ausdruck auf die Antwort angewendet, um den Rückgabewert zu extrahieren.</target>
         <note/>
       </trans-unit>
       <trans-unit id="If the display factory reset was performed properly, you should also reset all stored app DDC values to defaults." xml:space="preserve">
@@ -4784,10 +4855,12 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Integration Control" xml:space="preserve">
         <source>Integration Control</source>
+        <target state="translated">Integrations-Steuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integration control values on startup" xml:space="preserve">
         <source>Integration control values on startup</source>
+        <target state="translated">Integrations-Steuerungswerte beim Start</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integration settings" xml:space="preserve">
@@ -4847,6 +4920,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Invoke URL" xml:space="preserve">
         <source>Invoke URL</source>
+        <target state="translated">URL aufrufen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Issue mute command first, then set volume level to lowest setting" xml:space="preserve">
@@ -4906,6 +4980,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Kind" xml:space="preserve">
         <source>Kind</source>
+        <target state="translated">Art</target>
         <note/>
       </trans-unit>
       <trans-unit id="LG alt" xml:space="preserve">
@@ -4985,6 +5060,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Let the app control display hardware luminance (backlight for backlit displays) if this feature is available." xml:space="preserve">
         <source>Let the app control display hardware luminance (backlight for backlit displays) if this feature is available.</source>
+        <target state="translated">Ermöglicht der App, die Hardware-Helligkeit (Hintergrundbeleuchtung bei beleuchteten Displays) zu steuern, wenn diese Funktion verfügbar ist.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Let the app control screen brightness using Apple's display control service." xml:space="preserve">
@@ -5143,6 +5219,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Magnification" xml:space="preserve">
         <source>Magnification</source>
+        <target state="translated">Vergrößerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Main Status" xml:space="preserve">
@@ -5177,6 +5254,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Manage Custom Controls…" xml:space="preserve">
         <source>Manage Custom Controls…</source>
+        <target state="translated">Benutzerdefinierte Steuerungen verwalten…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Manage Display" xml:space="preserve">
@@ -5196,6 +5274,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Manage custom controls" xml:space="preserve">
         <source>Manage custom controls</source>
+        <target state="translated">Benutzerdefinierte Steuerungen verwalten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Manage…" xml:space="preserve">
@@ -5300,6 +5379,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Maximum value" xml:space="preserve">
         <source>Maximum value</source>
+        <target state="translated">Maximaler Wert</target>
         <note/>
       </trans-unit>
       <trans-unit id="Measured refresh rate:" xml:space="preserve">
@@ -5309,6 +5389,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Median" xml:space="preserve">
         <source>Median</source>
+        <target state="translated">Median</target>
         <note/>
       </trans-unit>
       <trans-unit id="Member displays" xml:space="preserve">
@@ -5393,6 +5474,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Minimum value" xml:space="preserve">
         <source>Minimum value</source>
+        <target state="translated">Kleinster Wert</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirror ${displayEntity} to ${targetDisplayEntity}." xml:space="preserve">
@@ -5402,7 +5484,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Mirror Display" xml:space="preserve">
         <source>Mirror Display</source>
-        <target state="translated">Bildschirme synchronisieren</target>
+        <target state="translated">Display synchronisieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mirror Screen" xml:space="preserve">
@@ -5550,6 +5632,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Mute control" xml:space="preserve">
         <source>Mute control</source>
+        <target state="translated">Stummschaltung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mute method" xml:space="preserve">
@@ -5629,6 +5712,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="New Custom Control" xml:space="preserve">
         <source>New Custom Control</source>
+        <target state="translated">Neue benutzerdefinierte Steuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="New Display Group" xml:space="preserve">
@@ -5713,6 +5797,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Noise Reduction" xml:space="preserve">
         <source>Noise Reduction</source>
+        <target state="translated">Rauschunterdrückung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Non-affected displays" xml:space="preserve">
@@ -5792,30 +5877,37 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Notification dispatch" xml:space="preserve">
         <source>Notification dispatch</source>
+        <target state="translated">Benachrichtigungsversand</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification name" xml:space="preserve">
         <source>Notification name</source>
+        <target state="translated">Benachrichtigungsname</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification name - OFF" xml:space="preserve">
         <source>Notification name - OFF</source>
+        <target state="translated">Benachrichtigungsname - AUS</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification name - ON" xml:space="preserve">
         <source>Notification name - ON</source>
+        <target state="translated">Benachrichtigungsname - AN</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification payload" xml:space="preserve">
         <source>Notification payload</source>
+        <target state="translated">Payload der Benachrichtigung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification payload - OFF" xml:space="preserve">
         <source>Notification payload - OFF</source>
+        <target state="translated">Payload der Benachrichtigung - AUS</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notification payload - ON" xml:space="preserve">
         <source>Notification payload - ON</source>
+        <target state="translated">Payload der Benachrichtigung - AN</target>
         <note/>
       </trans-unit>
       <trans-unit id="Notifications and Dock" xml:space="preserve">
@@ -5830,6 +5922,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Number of logical steps in the entire range" xml:space="preserve">
         <source>Number of logical steps in the entire range</source>
+        <target state="translated">Anzahl der logischen Schritte im gesamten Bereich</target>
         <note/>
       </trans-unit>
       <trans-unit id="Number of retry attempts on failure" xml:space="preserve">
@@ -5914,6 +6007,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Original" xml:space="preserve">
         <source>Original</source>
+        <target state="translated">Original</target>
         <note/>
       </trans-unit>
       <trans-unit id="Other Apple display" xml:space="preserve">
@@ -5953,10 +6047,14 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Parameters" xml:space="preserve">
         <source>Parameters</source>
+        <target state="translated">Parameter</target>
         <note/>
       </trans-unit>
       <trans-unit id="Parameters are reusable chunks of code/text that can be invoked in any integration configuration by referring to their identifiers. For example the `%@My parameter%@` code will invoke a parameter content identified as `My parameter`. Identifiers are case sensitive." xml:space="preserve">
         <source>Parameters are reusable chunks of code/text that can be invoked in any integration configuration by referring to their identifiers. For example the `%1$@My parameter%2$@` code will invoke a parameter content identified as `My parameter`. Identifiers are case sensitive.</source>
+        <target state="translated">Parameter sind wiederverwendbare Code- oder Textbausteine, die in jeder Integrationskonfiguration über ihre Bezeichner aufgerufen werden können.  
+Zum Beispiel ruft der Code `%1$s@Mein Parameter%2$s` einen Parameterinhalt mit der Bezeichnung „Mein Parameter“ auf.  
+Bezeichner unterscheiden zwischen Groß- und Kleinschreibung.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Paste" xml:space="preserve">
@@ -6001,6 +6099,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Periodically read and update current value from device" xml:space="preserve">
         <source>Periodically read and update current value from device</source>
+        <target state="translated">Den aktuellen Wert vom Gerät periodisch auslesen und aktualisieren.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Periodically read and update current value from display" xml:space="preserve">
@@ -6289,6 +6388,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Range-based control" xml:space="preserve">
         <source>Range-based control</source>
+        <target state="translated">Bereichsbasierte Steuerung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Rate" xml:space="preserve">
@@ -6298,6 +6398,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Read &amp; Update From Device" xml:space="preserve">
         <source>Read &amp; Update From Device</source>
+        <target state="translated">Vom Geräte lesen &amp; aktualisieren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Read failed" xml:space="preserve">
@@ -6317,6 +6418,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Read values from device" xml:space="preserve">
         <source>Read values from device</source>
+        <target state="translated">Gerätewert lesen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Read values from display" xml:space="preserve">
@@ -6531,6 +6633,7 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Remove Custom Feature" xml:space="preserve">
         <source>Remove Custom Feature</source>
+        <target state="translated">Benutzerdefinierte Funktion entfernen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove Factory Color Profiles?" xml:space="preserve">
@@ -6540,10 +6643,12 @@ Nicht alle Displays unterstützen DDC-Stromaktionen. DDC-Stromaktionen können b
       </trans-unit>
       <trans-unit id="Remove Feature" xml:space="preserve">
         <source>Remove Feature</source>
+        <target state="translated">Funktion entfernen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove Filter Window Configuration" xml:space="preserve">
         <source>Remove Filter Window Configuration</source>
+        <target state="translated">Filterfenster-Konfiguration entfernen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove Other Activation(s)" xml:space="preserve">
@@ -6635,6 +6740,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Reset All Display System Settings…" xml:space="preserve">
         <source>Reset All Display System Settings…</source>
+        <target state="translated">Alle Displayeinstellungen zurücksetzen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Reset All Settings" xml:space="preserve">
@@ -6684,6 +6790,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Reset System Settings" xml:space="preserve">
         <source>Reset System Settings</source>
+        <target state="translated">Systemeinstellungen zurücksetzen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Reset VMM7100 HDMI Adapter" xml:space="preserve">
@@ -6698,6 +6805,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Reset Video Filters" xml:space="preserve">
         <source>Reset Video Filters</source>
+        <target state="translated">Videofilter zurücksetzen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Reset Warning Dismissals" xml:space="preserve">
@@ -6712,6 +6820,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Reset and Reboot" xml:space="preserve">
         <source>Reset and Reboot</source>
+        <target state="translated">Zurücksetzen und Neustarten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Reset color adjustments for ${displayEntity}." xml:space="preserve">
@@ -6871,30 +6980,37 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Return value is processed from the combined output of the script and matched to the specified expected return contents directly or as a regular expressions." xml:space="preserve">
         <source>Return value is processed from the combined output of the script and matched to the specified expected return contents directly or as a regular expressions.</source>
+        <target state="translated">Der Rückgabewert wird aus der kombinierten Skriptausgabe verarbeitet und direkt oder mithilfe regulärer Ausdrücke mit dem erwarteten Rückgabewert verglichen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Return value is processed from the combined output of the script expecting a valid number (optional minus sign, one or more digits, with optional decimal point followed by additional digits)." xml:space="preserve">
         <source>Return value is processed from the combined output of the script expecting a valid number (optional minus sign, one or more digits, with optional decimal point followed by additional digits).</source>
+        <target state="translated">Der Rückgabewert wird aus der kombinierten Skriptausgabe verarbeitet und als gültige Zahl erwartet (optional Minuszeichen, eine oder mehrere Ziffern, optionaler Dezimalpunkt mit weiteren Ziffern).</target>
         <note/>
       </trans-unit>
       <trans-unit id="Return value is processed from the combined output of the script." xml:space="preserve">
         <source>Return value is processed from the combined output of the script.</source>
+        <target state="translated">Der Rückgabewert wird aus der kombinierten Skriptausgabe verarbeitet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Return value is processed from the response expecting a valid number (optional minus sign, one or more digits, with optional decimal point followed by additional digits)." xml:space="preserve">
         <source>Return value is processed from the response expecting a valid number (optional minus sign, one or more digits, with optional decimal point followed by additional digits).</source>
+        <target state="translated">Der Rückgabewert wird aus der Antwort verarbeitet und als gültige Zahl erwartet (optional Minuszeichen, eine oder mehrere Ziffern, optionaler Dezimalpunkt mit weiteren Ziffern).</target>
         <note/>
       </trans-unit>
       <trans-unit id="Return value regex" xml:space="preserve">
         <source>Return value regex</source>
+        <target state="translated">Regulärer Ausdruck für Rückgabewert</target>
         <note/>
       </trans-unit>
       <trans-unit id="Returned content - OFF (%@)" xml:space="preserve">
         <source>Returned content - OFF (%@)</source>
+        <target state="translated">Zurückgegebener Inhalt – AUS (%@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Returned content - ON (%@)" xml:space="preserve">
         <source>Returned content - ON (%@)</source>
+        <target state="translated">Zurückgegebener Inhalt – EIN (%@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Right" xml:space="preserve">
@@ -7009,6 +7125,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Run shell script" xml:space="preserve">
         <source>Run shell script</source>
+        <target state="translated">Shell-Skript ausführen</target>
         <note/>
       </trans-unit>
       <trans-unit id="SDR peak brightness adjustment is available in macOS Sequoia and newer. With this enabled, the app deals with this HDR display like it would on macOS Sonoma or earlier. You can still use the Control Center for SDR peak brightness adjustment." xml:space="preserve">
@@ -7033,6 +7150,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Saturation" xml:space="preserve">
         <source>Saturation</source>
+        <target state="translated">Sättigung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Save Calibration" xml:space="preserve">
@@ -7077,6 +7195,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Script to get current value (%@)" xml:space="preserve">
         <source>Script to get current value (%@)</source>
+        <target state="translated">Skript zum Abrufen des aktuellen Werts (%@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Security token" xml:space="preserve">
@@ -7091,10 +7210,12 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Select Control…" xml:space="preserve">
         <source>Select Control…</source>
+        <target state="translated">Steuerung auswählen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Select Custom Control…" xml:space="preserve">
         <source>Select Custom Control…</source>
+        <target state="translated">Benutzerdefinierte Steuerung auswählen...</target>
         <note/>
       </trans-unit>
       <trans-unit id="Select a common aspect ratio for the virtual screen. The app creates a flexible resolution list based on this." xml:space="preserve">
@@ -7213,6 +7334,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Sepia" xml:space="preserve">
         <source>Sepia</source>
+        <target state="translated">Sepia</target>
         <note/>
       </trans-unit>
       <trans-unit id="Serial number" xml:space="preserve">
@@ -7412,26 +7534,32 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Shadow" xml:space="preserve">
         <source>Shadow</source>
+        <target state="translated">Schatten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Sharpness" xml:space="preserve">
         <source>Sharpness</source>
+        <target state="translated">Schärfe</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shell script (%@)" xml:space="preserve">
         <source>Shell script (%@)</source>
+        <target state="translated">Shell-Skript (%@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shell script (%@) - OFF" xml:space="preserve">
         <source>Shell script (%@) - OFF</source>
+        <target state="translated">Shell-Skript (%@) - AUS</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shell script (%@) - ON" xml:space="preserve">
         <source>Shell script (%@) - ON</source>
+        <target state="translated">Shell-Skript (%@) - AN</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shell script to be invoked when the ON state is set." xml:space="preserve">
         <source>Shell script to be invoked when the ON state is set.</source>
+        <target state="translated">Shell-Skript, das ausgeführt wird, wenn der EIN-Zustand gesetzt ist.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Show %@ in the macOS Dock" xml:space="preserve">
@@ -7729,6 +7857,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Some displays do not support hardware brightness control in HDR mode. Enabling this for compatible displays allows brightness control while preserving unclipped HDR content." xml:space="preserve">
         <source>Some displays do not support hardware brightness control in HDR mode. Enabling this for compatible displays allows brightness control while preserving unclipped HDR content.</source>
+        <target state="translated">Einige Displays unterstützen im HDR-Modus keine Hardware-Helligkeitssteuerung. Das Aktivieren dieser Option ermöglicht bei kompatiblen Displays die Helligkeitssteuerung unter Erhalt von unbeschnittenem HDR-Inhalt.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Some displays forget changes made via DDC commands after sleep. With this enabled, the app reapplies DDC settings every time the display wakes." xml:space="preserve">
@@ -7798,6 +7927,7 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="Standard step size" xml:space="preserve">
         <source>Standard step size</source>
+        <target state="translated">Standard Schrittgröße</target>
         <note/>
       </trans-unit>
       <trans-unit id="Start Automatically" xml:space="preserve">
@@ -7827,6 +7957,8 @@ Das Entfernen aller Aktivierungen setzt alles auf Null.</target>
       </trans-unit>
       <trans-unit id="State is processed from the response and matched to the specified expected return contents directly or as a regular expressions." xml:space="preserve">
         <source>State is processed from the response and matched to the specified expected return contents directly or as a regular expressions.</source>
+        <target state="translated">Der Status wird aus der Antwort verarbeitet und direkt oder mithilfe regulärer Ausdrücke mit dem erwarteten Rückgabewert verglichen.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="Status: Pro License Activated" xml:space="preserve">
@@ -8310,6 +8442,7 @@ Trenne im Falle eines Fehlers die physische Verbindung zum Display und verbinde 
       </trans-unit>
       <trans-unit id="Thermal" xml:space="preserve">
         <source>Thermal</source>
+        <target state="translated">Temperatur</target>
         <note/>
       </trans-unit>
       <trans-unit id="These three identifiers (serial number, vendor and model ID) serve as the basis for display identification in macOS. If any of these three identifiers are changed, the system will assign a new identity (UUID) to the virtual screen and treat it as newly connected display." xml:space="preserve">
@@ -8349,10 +8482,14 @@ Trenne im Falle eines Fehlers die physische Verbindung zum Display und verbinde 
       </trans-unit>
       <trans-unit id="This control is now a placeholder, does not perform any action." xml:space="preserve">
         <source>This control is now a placeholder, does not perform any action.</source>
+        <target state="translated">Dieses Steuerelement ist jetzt ein Platzhalter und führt keine Aktion aus.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="This custom control is configured for one or more displays or display groups. Deleting it will also remove it from them." xml:space="preserve">
         <source>This custom control is configured for one or more displays or display groups. Deleting it will also remove it from them.</source>
+        <target state="translated">Dieses benutzerdefinierte Steuerelement ist für ein oder mehrere Displays bzw. Display-Gruppen konfiguriert. Wird es gelöscht, wird es auch dort entfernt.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="This display group does not have member displays." xml:space="preserve">
@@ -8376,6 +8513,8 @@ Bitte beachte, dass nicht alle Displays DDC-Stromaktionen unterstützen und eini
       </trans-unit>
       <trans-unit id="This format string specifies how the control's internal value is formatted and sent to the device." xml:space="preserve">
         <source>This format string specifies how the control's internal value is formatted and sent to the device.</source>
+        <target state="translated">Diese Formatzeichenfolge legt fest, wie der interne Wert des Steuerelements formatiert und an das Gerät gesendet wird.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="This is a workaround of an issue present in some versions of macOS Sonoma which occasionally prevents a display's custom configuration to be loaded properly. With this setting the app attempts to reinitialize the display if flexible scaling resolutions seem to be missing." xml:space="preserve">
@@ -8537,6 +8676,8 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="This will appear as the control's name throughout the app. Should be unique to avoid confusion." xml:space="preserve">
         <source>This will appear as the control's name throughout the app. Should be unique to avoid confusion.</source>
+        <target state="translated">Dies erscheint als Name des Steuerelements in der gesamten App und sollte eindeutig sein, um Verwechslungen zu vermeiden.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="Title Bar &amp; Window Controls" xml:space="preserve">
@@ -8546,10 +8687,14 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="To control features that have an on/off state. Can be used for group-level synchronization." xml:space="preserve">
         <source>To control features that have an on/off state. Can be used for group-level synchronization.</source>
+        <target state="translated">Zum Steuern von Funktionen mit einem Ein-/Aus-Zustand. Kann für Synchronisierung auf Gruppenebene verwendet werden.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="To control features that operate on a range (like brightness). Can be used for group-level synchronization." xml:space="preserve">
         <source>To control features that operate on a range (like brightness). Can be used for group-level synchronization.</source>
+        <target state="translated">Zum Steuern von Funktionen mit einem Wertebereich (z. B. Helligkeit). Kann für Synchronisierung auf Gruppenebene verwendet werden.
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="To make your Apple keyboard's brightness and volume keys control your external display, please add the app to **System Settings &gt; Privacy &amp; Security &gt; Accessibility**! After this, you'll have to restart the app. Alternatively, you can disable native keyboard control in Settings." xml:space="preserve">
@@ -8569,6 +8714,8 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Toggle (on/off) control" xml:space="preserve">
         <source>Toggle (on/off) control</source>
+        <target state="translated">Ein-/Aus-Steuerelement
+</target>
         <note/>
       </trans-unit>
       <trans-unit id="Toggle Auto Brightness" xml:space="preserve">
@@ -8643,7 +8790,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Toggle built-in display" xml:space="preserve">
         <source>Toggle built-in display</source>
-        <target state="translated">Integrierten Bildschirm umschalten</target>
+        <target state="translated">Integrierten Display umschalten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Toggle cropping" xml:space="preserve">
@@ -8842,6 +8989,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Type" xml:space="preserve">
         <source>Type</source>
+        <target state="translated">Typ</target>
         <note/>
       </trans-unit>
       <trans-unit id="Typical optimal values for contrast are 50%, 70%, 75%, 100%. Make sure you select a value that does not create an issue with white saturation!" xml:space="preserve">
@@ -8876,6 +9024,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="URL" xml:space="preserve">
         <source>URL</source>
+        <target state="translated">URL</target>
         <note/>
       </trans-unit>
       <trans-unit id="URL call (http/s or custom URL scheme) to be performed when the ON state is set." xml:space="preserve">
@@ -9025,6 +9174,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Unsharp Mask" xml:space="preserve">
         <source>Unsharp Mask</source>
+        <target state="translated">Unschärfenmaske</target>
         <note/>
       </trans-unit>
       <trans-unit id="Unspecified" xml:space="preserve">
@@ -9064,7 +9214,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Use %@ as menu icon when the app is preventing display sleep" xml:space="preserve">
         <source>Use %@ as menu icon when the app is preventing display sleep</source>
-        <target state="translated">Ein alternatives Symbol verwenden, wenn die App so konfiguriert ist, dass sie den Ruhezustand des Bildschirms verhindert.</target>
+        <target state="translated">Ein alternatives Symbol verwenden, wenn die App so konfiguriert ist, dass sie den Ruhezustand des Displays verhindert.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Use Metal for image adjustments" xml:space="preserve">
@@ -9078,7 +9228,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Use an alternate icon when the app is configured to prevent display sleep." xml:space="preserve">
         <source>Use an alternate icon when the app is configured to prevent display sleep.</source>
-        <target state="translated">Ein alternatives Symbol verwenden, wenn die App so konfiguriert ist, dass sie den Ruhezustand des Bildschirms verhindert.</target>
+        <target state="translated">Ein alternatives Symbol verwenden, wenn die App so konfiguriert ist, dass sie den Ruhezustand des Displays verhindert.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Use custom resolution list" xml:space="preserve">
@@ -9203,14 +9353,17 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Video Filter Window" xml:space="preserve">
         <source>Video Filter Window</source>
+        <target state="translated">Videofilter-Fenster</target>
         <note/>
       </trans-unit>
       <trans-unit id="Video Filter Window%@" xml:space="preserve">
         <source>Video Filter Window%@</source>
+        <target state="translated">Videofilter-Fenster%@</target>
         <note/>
       </trans-unit>
       <trans-unit id="Video Filters" xml:space="preserve">
         <source>Video Filters</source>
+        <target state="translated">Videofilter</target>
         <note/>
       </trans-unit>
       <trans-unit id="Vignette" xml:space="preserve">
@@ -9334,6 +9487,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Volume control" xml:space="preserve">
         <source>Volume control</source>
+        <target state="translated">Lautstärgeregelung</target>
         <note/>
       </trans-unit>
       <trans-unit id="Wait time between backlight state change operations" xml:space="preserve">
@@ -9413,7 +9567,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="When enabled, this display will not trigger the disconnection of the built-in display when it is set to disconnect upon the connection of an external display." xml:space="preserve">
         <source>When enabled, this display will not trigger the disconnection of the built-in display when it is set to disconnect upon the connection of an external display.</source>
-        <target state="translated">Wenn aktiviert, wird dieser Bildschirm nicht das Trennen des integrierten Bildschirms auslösen, wenn dieser auf Trennung bei Verbindung eines externen Bildschirms eingestellt ist.</target>
+        <target state="translated">Wenn aktiviert, wird dieser Display nicht das Trennen des integrierten Displays auslösen, wenn dieser auf Trennung bei Verbindung eines externen Displays eingestellt ist.</target>
         <note/>
       </trans-unit>
       <trans-unit id="When expanding a menu item, automatically hide other items under the given device / menu block. This helps keep the menu smaller." xml:space="preserve">
@@ -9433,6 +9587,9 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="When this is enabled, the app will use hardware brightness for combined brightness control instead of the SDR peak brightness adjustment control (HDR brightness control) provided by macOS. You can still adjust the SDR peak brightness in Control Center - these adjustments will influence the upscaling (if available) headroom provided by the app. Not all displays support hardware brightness control in HDR mode." xml:space="preserve">
         <source>When this is enabled, the app will use hardware brightness for combined brightness control instead of the SDR peak brightness adjustment control (HDR brightness control) provided by macOS. You can still adjust the SDR peak brightness in Control Center - these adjustments will influence the upscaling (if available) headroom provided by the app. Not all displays support hardware brightness control in HDR mode.</source>
+        <target state="translated">Wenn diese Option aktiviert ist, verwendet die App die Hardware-Helligkeit zur kombinierten Helligkeitssteuerung anstelle der von macOS bereitgestellten SDR-Spitzenhelligkeitsregelung (HDR-Helligkeitsregelung).
+Die SDR-Spitzenhelligkeit kann weiterhin im Kontrollzentrum angepasst werden – diese Anpassungen beeinflussen den vom Programm bereitgestellten (falls verfügbar) Spielraum für das Hochskalieren.
+Nicht alle Displays unterstützen die Hardware-Helligkeitssteuerung im HDR-Modus.</target>
         <note/>
       </trans-unit>
       <trans-unit id="When volume reaches 0%…" xml:space="preserve">
@@ -9517,6 +9674,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="Write last used values to device" xml:space="preserve">
         <source>Write last used values to device</source>
+        <target state="translated">Zuletzt genutzten Wert auf das Gerät schreiben</target>
         <note/>
       </trans-unit>
       <trans-unit id="Write last used values to display" xml:space="preserve">
@@ -9526,6 +9684,7 @@ Du kannst diese Mitteilung schließen - in diesem Fall werden die Änderungen ü
       </trans-unit>
       <trans-unit id="X-Ray" xml:space="preserve">
         <source>X-Ray</source>
+        <target state="translated">Röntgen</target>
         <note/>
       </trans-unit>
       <trans-unit id="XDR Configuration" xml:space="preserve">
@@ -9679,6 +9838,7 @@ Eine vorherige Aktivierung wurde automatisch entfernt, um Platz für diese neue 
       </trans-unit>
       <trans-unit id="exact" xml:space="preserve">
         <source>exact</source>
+        <target state="translated">exakt</target>
         <note/>
       </trans-unit>
       <trans-unit id="forced" xml:space="preserve">
@@ -9738,6 +9898,7 @@ Eine vorherige Aktivierung wurde automatisch entfernt, um Platz für diese neue 
       </trans-unit>
       <trans-unit id="regex" xml:space="preserve">
         <source>regex</source>
+        <target state="translated">regex</target>
         <note/>
       </trans-unit>
       <trans-unit id="seconds" xml:space="preserve">


### PR DESCRIPTION
 Translated NSLocalNetworkUsageDescription string for local network privacy notice.
- Updated UI string entries for display configuration, HDR handling, and control labeling.
- Ensured consistency in grammar, punctuation, and terminology across new and existing entries.

Related to commit 9b4705. Improves localisation coverage and clarity in BetterDisplay.

🦧✌🏻