### PR TITLE
Arabic: translate 4 new strings

### DIFF
--- a/BetterDisplay Localizations/ar.xcloc/Localized Contents/ar.xliff
+++ b/BetterDisplay Localizations/ar.xcloc/Localized Contents/ar.xliff
@@ -1060,6 +1060,7 @@ You can do this in System Settings or the app can do it for you (administrator c
       </trans-unit>
       <trans-unit id="Align" xml:space="preserve">
         <source>Align</source>
+        <target state="translated">محاذاة</target>
         <note/>
       </trans-unit>
       <trans-unit id="All VMM7100-based USB-C to HDMI devices are affected - make sure you enable the appropriate reinitialization option for all displays connected with such devices to avoid the need for manual power cycles." xml:space="preserve">
@@ -1620,6 +1621,7 @@ AliPay available in China.</source>
       </trans-unit>
       <trans-unit id="Arrange" xml:space="preserve">
         <source>Arrange</source>
+        <target state="translated">ترتيب</target>
         <note/>
       </trans-unit>
       <trans-unit id="Arrange %@ next to" xml:space="preserve">
@@ -6940,6 +6942,7 @@ Not all displays support screen control operations. These operations can cause i
       </trans-unit>
       <trans-unit id="Move Displays" xml:space="preserve">
         <source>Move Displays</source>
+        <target state="translated">نقل الشاشات</target>
         <note/>
       </trans-unit>
       <trans-unit id="Move Screen" xml:space="preserve">
@@ -12683,6 +12686,7 @@ Most displays do not allow EDID write for security reasons, some displays requir
       </trans-unit>
       <trans-unit id="⚠️ This OSD style is available for brightness and volume only." xml:space="preserve">
         <source>⚠️ This OSD style is available for brightness and volume only.</source>
+        <target state="translated">⚠️ نمط الـ OSD هذا متاح للسطوع ومستوى الصوت فقط.</target>
         <note/>
       </trans-unit>
       <trans-unit id="⚠️ This display does not support color table adjustments or color table adjustments are disabled. The app uses overlay based dimming instead." xml:space="preserve">


### PR DESCRIPTION
First Arabic update as a Pull Request rather than an attached zip, as you suggested.

Translates the 4 new strings added in "Updated strings":

| String | Arabic | Note |
| --- | --- | --- |
| `Align` | محاذاة | |
| `Arrange` | ترتيب | |
| `Move Displays` | نقل الشاشات | |
| `⚠️ This OSD style is available for brightness and volume only.` | ⚠️ نمط الـ OSD هذا متاح للسطوع ومستوى الصوت فقط. | Wording follows the two existing system-OSD warnings, with "style" instead of "system" |

Arabic is complete again: 2502 of 2520, the other 18 marked `translate="no"`. The diff is 4 added lines and nothing else.

One note on `Align` and `Arrange`: they are close in Arabic and I could not tell from the catalog whether they appear together in the same menu. If they do and the distinction matters, tell me what each one does and I will re-word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHfLYe14j5CcK6NSEK2sPK